### PR TITLE
NAS-139548 / 26.0.0-BETA.2 / Fix USB devices without vendor/product description being marked unavailable (by Qubad786)

### DIFF
--- a/truenas_pylibvirt/utils/usb.py
+++ b/truenas_pylibvirt/utils/usb.py
@@ -69,7 +69,7 @@ def get_usb_device_details(udev_device: UdevDevice) -> dict[str, Any]:
     data['capability']['product'] = props.get('ID_MODEL_FROM_DATABASE') or props.get('ID_MODEL') or None
 
     # Check if all required keys have values (matching middleware behavior)
-    required_keys = ['bus', 'device', 'vendor_id', 'product_id', 'vendor', 'product']
+    required_keys = ['bus', 'device', 'vendor_id', 'product_id']
     missing_keys = [k for k in required_keys if data['capability'][k] is None]
 
     if missing_keys:


### PR DESCRIPTION
##  Problem

USB devices that do not report a **vendor** or **product description** are currently marked as **unavailable** by the system.

As a result, such devices become unusable for the user, even though they may function correctly at the hardware level.

## Solution

Remove vendor and product description from the list of required fields

Allow USB devices without these descriptive strings to be recognized as available
This ensures:

* The device is still recognized and selectable
* Users can utilize the device despite missing metadata


Original PR: https://github.com/truenas/truenas_pylibvirt/pull/26
