### PR TITLE
NAS-140194 / 27.0.0-BETA.1 / Add __all__ exports for mypy strict compatibility

### DIFF
--- a/truenas_pylibvirt/__init__.py
+++ b/truenas_pylibvirt/__init__.py
@@ -16,3 +16,29 @@ from .error import Error, DomainDoesNotExistError  # noqa
 from .libvirtd.connection import Connection  # noqa
 from .libvirtd.connection_manager import ConnectionManager  # noqa
 from .libvirtd.service_delegate import ServiceDelegate  # noqa
+
+__all__ = [
+    'ContainerCapabilitiesPolicy',
+    'ContainerDomain',
+    'ContainerDomainConfiguration',
+    'ContainerIdmapConfiguration',
+    'ContainerIdmapConfigurationItem',
+    'Connection',
+    'ConnectionManager',
+    'BaseDomain',
+    'DiskStorageDevice',
+    'DomainDoesNotExistError',
+    'DomainManagers',
+    'Error',
+    'NICDevice',
+    'NICDeviceModel',
+    'NICDeviceType',
+    'ServiceDelegate',
+    'StorageDeviceIoType',
+    'StorageDeviceType',
+    'Time',
+    'VmBootloader',
+    'VmCpuMode',
+    'VmDomain',
+    'VmDomainConfiguration',
+]

--- a/truenas_pylibvirt/device/__init__.py
+++ b/truenas_pylibvirt/device/__init__.py
@@ -9,3 +9,22 @@ from .nic import NICDevice, NICDeviceType, NICDeviceModel  # noqa
 from .pci import PCIDevice  # noqa
 from .storage import DiskStorageDevice, RawStorageDevice, StorageDeviceType, StorageDeviceIoType  # noqa
 from .usb import USBDevice  # noqa
+
+__all__ = [
+    'CDROMDevice',
+    'Device',
+    'DeviceDelegate',
+    'DiskStorageDevice',
+    'DisplayDevice',
+    'DisplayDeviceType',
+    'FilesystemDevice',
+    'GPUDevice',
+    'NICDevice',
+    'NICDeviceModel',
+    'NICDeviceType',
+    'PCIDevice',
+    'RawStorageDevice',
+    'StorageDeviceIoType',
+    'StorageDeviceType',
+    'USBDevice',
+]


### PR DESCRIPTION
## Context

For middleware container plugin conversion to typesafe pattern (https://github.com/truenas/middleware/pull/18403), `mypy --strict` CI check fails with `attr-defined` errors for all imports from `truenas_pylibvirt` and `truenas_pylibvirt.device`. In strict mode, mypy requires re-exports from `__init__.py` to be explicit — plain `from .x import Y` is treated as a private import. Adding `__all__` to both `truenas_pylibvirt/__init__.py` and `truenas_pylibvirt/device/__init__.py` makes all public symbols explicitly exported.