### PR TITLE
NAS-140421 / 26.0.0-BETA.2 / Fix DRMBase missing driver_xml() implementation preventing INTEL GPU instantiation (by Qubad786)

### DIFF
--- a/truenas_pylibvirt/device/gpu_utils.py
+++ b/truenas_pylibvirt/device/gpu_utils.py
@@ -116,6 +116,9 @@ class DRMBase(GPUBase):
             ),
         ]
 
+    def driver_xml(self) -> list[ElementTree.Element]:
+        return []
+
 
 class AMD(DRMBase, gpu_type='AMD'):
 


### PR DESCRIPTION
## Problem

Recent mypy-related changes (https://github.com/truenas/truenas_pylibvirt/pull/24) introduced a regression in the Intel GPU utilities.
An abstract method was added to the base class, which made the Intel GPU class
implicitly abstract as well. Because not all abstract methods were implemented,
the class became non-instantiable, causing initialization of the Intel GPU
utilities to fail.

## Solution

Implemented (override) all required abstract methods in the Intel GPU class so
that it is no longer abstract and can be instantiated successfully.

Original PR: https://github.com/truenas/truenas_pylibvirt/pull/29
