### PR TITLE
NAS-140716 / 26.0.0-BETA.2 / Correct CPU model validation in custom CPU mode XML generation (by Qubad786)

### DIFF
--- a/truenas_pylibvirt/domain/vm/xml.py
+++ b/truenas_pylibvirt/domain/vm/xml.py
@@ -75,7 +75,7 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
         ))
 
         if self.domain.configuration.cpu_mode == VmCpuMode.CUSTOM:
-            if self.domain.configuration.cpu_model and get_cpu_model_choices(self.domain.configuration.cpu_model):
+            if (model := self.domain.configuration.cpu_model) and model in get_cpu_model_choices():
                 # Right now this is best effort for the domain to start with specified CPU Model and not fallback
                 # However if some features are missing in the host, qemu will right now still start the domain
                 # and mark them as missing. We should perhaps make this configurable in the future to control
@@ -83,7 +83,7 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
                 cpu_children.append(xml_element(
                     "model",
                     attributes={"fallback": "forbid"},
-                    text=self.domain.configuration.cpu_model,
+                    text=model,
                 ))
 
         if self.domain.configuration.cpu_mode == VmCpuMode.HOST_PASSTHROUGH:


### PR DESCRIPTION
## Problem

When starting a VM configured with `cpu_mode=CUSTOM` and a non-empty `cpu_model`, XML generation in `VmDomainXmlGenerator._cpu_xml` raised a `TypeError`. The conditional called `get_cpu_model_choices(self.domain.configuration.cpu_model)`, but `get_cpu_model_choices()` is defined to take no arguments — it returns a dict of all available CPU models on the host. As a result, any VM relying on a custom CPU model could not be started.

## Solution

Updated the condition in `truenas_pylibvirt/domain/vm/xml.py` to call `get_cpu_model_choices()` with no arguments and check membership of the configured `cpu_model` against the returned dict. Used a walrus assignment to avoid repeated attribute access when emitting the `<model>` element. The fallback-forbid behavior is preserved, so VMs with an unavailable CPU model continue to skip the element rather than forcing a start failure.


Original PR: https://github.com/truenas/truenas_pylibvirt/pull/33
