### PR TITLE
NAS-140953 / 26.0.0-BETA.2 / Fix devices cleanup on domain being shutdown (by Qubad786)

### DIFF
--- a/truenas_pylibvirt/domain/manager.py
+++ b/truenas_pylibvirt/domain/manager.py
@@ -15,7 +15,7 @@ from .start_validator import StartValidator, StartValidationContext
 logger = logging.getLogger(__name__)
 
 STOPPED_STATES = [DomainState.SHUTDOWN, DomainState.SHUTOFF, DomainState.CRASHED]
-STOPPED_EVENTS = [VirDomainEvent.STOPPED, VirDomainEvent.SHUTDOWN, VirDomainEvent.UNDEFINED]
+STOPPED_EVENTS = [VirDomainEvent.STOPPED, VirDomainEvent.UNDEFINED]
 
 
 class StartedDomain:


### PR DESCRIPTION
## Problem

QEMU emits the `SHUTDOWN` event when the guest has shut down but before the QEMU process exits completely. This event is currently used to close the device context manager where we assume that the domain has exited and if any cleanup is required for the device in question, that happens.

For PCI passthrough devices, this creates a race condition where devices may be reattached to the host while QEMU is still running and holding them. On Windows guests, this can prevent PCI devices from being successfully reattached to the host.

## Solution

Remove the `SHUTDOWN` event from `STOPPED_EVENTS` so the device context manager is only closed after the QEMU process has fully exited, ensuring passthrough devices are safely released before reattachment.

Original PR: https://github.com/truenas/truenas_pylibvirt/pull/40
