### PR TITLE
NAS-140766 / 27.0.0-BETA.1 / Allow multiple uid/gid ranges in ContainerIdmapConfiguration

### DIFF
--- a/tests/domain/test_container_idmap.py
+++ b/tests/domain/test_container_idmap.py
@@ -1,0 +1,156 @@
+"""Tests for container idmap configuration and XML generation."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import Mock
+
+import pytest
+
+# Stub the libvirt module so the library's device imports don't blow up in
+# environments without the python3-libvirt system package installed.
+sys.modules.setdefault("libvirt", types.ModuleType("libvirt"))
+
+from truenas_pylibvirt.domain.container.configuration import (  # noqa: E402
+    ContainerIdmapConfiguration,
+    ContainerIdmapConfigurationItem,
+)
+from truenas_pylibvirt.domain.container.xml import ContainerDomainXmlGenerator  # noqa: E402
+
+
+def _item(start: int, target: int, count: int) -> ContainerIdmapConfigurationItem:
+    return ContainerIdmapConfigurationItem(start=start, target=target, count=count)
+
+
+def test_single_entry_idmap_is_valid():
+    cfg = ContainerIdmapConfiguration(
+        uid=[_item(0, 2147000001, 65536)],
+        gid=[_item(0, 2147000001, 65536)],
+    )
+    assert cfg.uid[0].target == 2147000001
+
+
+def test_multi_entry_idmap_with_passthrough_segment_is_valid():
+    # Container 0..567 -> host 2147000001..2147000568, container 568 -> host 568,
+    # container 569..65535 -> host 2147000570..2147065536
+    cfg = ContainerIdmapConfiguration(
+        uid=[
+            _item(0, 2147000001, 568),
+            _item(568, 568, 1),
+            _item(569, 2147000570, 64967),
+        ],
+        gid=[
+            _item(0, 2147000001, 568),
+            _item(568, 568, 1),
+            _item(569, 2147000570, 64967),
+        ],
+    )
+    assert len(cfg.uid) == 3
+
+
+def test_empty_uid_list_rejected():
+    with pytest.raises(ValueError, match="At least one uid idmap entry is required"):
+        ContainerIdmapConfiguration(uid=[], gid=[_item(0, 1, 1)])
+
+
+def test_empty_gid_list_rejected():
+    with pytest.raises(ValueError, match="At least one gid idmap entry is required"):
+        ContainerIdmapConfiguration(uid=[_item(0, 1, 1)], gid=[])
+
+
+def test_zero_count_rejected():
+    with pytest.raises(ValueError, match="count must be positive"):
+        ContainerIdmapConfiguration(uid=[_item(0, 1, 0)], gid=[_item(0, 1, 1)])
+
+
+def test_negative_start_rejected():
+    with pytest.raises(ValueError, match="start/target must be non-negative"):
+        ContainerIdmapConfiguration(uid=[_item(-1, 1, 1)], gid=[_item(0, 1, 1)])
+
+
+def test_negative_target_rejected():
+    with pytest.raises(ValueError, match="start/target must be non-negative"):
+        ContainerIdmapConfiguration(uid=[_item(0, -1, 1)], gid=[_item(0, 1, 1)])
+
+
+def test_overlapping_container_ranges_rejected():
+    with pytest.raises(ValueError, match="container-side ranges overlap"):
+        ContainerIdmapConfiguration(
+            uid=[_item(0, 1000, 100), _item(50, 2000, 100)],
+            gid=[_item(0, 1, 1)],
+        )
+
+
+def test_overlapping_host_ranges_rejected():
+    with pytest.raises(ValueError, match="host-side ranges overlap"):
+        ContainerIdmapConfiguration(
+            uid=[_item(0, 1000, 100), _item(200, 1050, 100)],
+            gid=[_item(0, 1, 1)],
+        )
+
+
+def test_xml_emits_one_element_per_item():
+    cfg = ContainerIdmapConfiguration(
+        uid=[
+            _item(0, 2147000001, 568),
+            _item(568, 568, 1),
+            _item(569, 2147000570, 64967),
+        ],
+        gid=[
+            _item(0, 2147000001, 568),
+            _item(568, 568, 1),
+            _item(569, 2147000570, 64967),
+        ],
+    )
+
+    mock_domain = Mock()
+    mock_domain.configuration.idmap = cfg
+
+    generator = ContainerDomainXmlGenerator.__new__(ContainerDomainXmlGenerator)
+    generator.domain = mock_domain
+
+    misc = generator._misc_xml()
+    assert len(misc) == 1
+    idmap_el = misc[0]
+    assert idmap_el.tag == "idmap"
+
+    uid_children = idmap_el.findall("uid")
+    gid_children = idmap_el.findall("gid")
+    assert len(uid_children) == 3
+    assert len(gid_children) == 3
+
+    apps_uid = next(u for u in uid_children if u.get("start") == "568")
+    assert apps_uid.get("target") == "568"
+    assert apps_uid.get("count") == "1"
+
+    base_uid = next(u for u in uid_children if u.get("start") == "0")
+    assert base_uid.get("target") == "2147000001"
+    assert base_uid.get("count") == "568"
+
+
+def test_xml_omits_idmap_when_configuration_is_none():
+    mock_domain = Mock()
+    mock_domain.configuration.idmap = None
+
+    generator = ContainerDomainXmlGenerator.__new__(ContainerDomainXmlGenerator)
+    generator.domain = mock_domain
+
+    misc = generator._misc_xml()
+    assert misc == []
+
+
+def test_x_mount_idmap_spec_is_space_separated():
+    from truenas_pylibvirt.domain.container.domain import ContainerDomain
+
+    domain = ContainerDomain.__new__(ContainerDomain)
+    items = [
+        _item(0, 2147000001, 568),
+        _item(568, 568, 1),
+        _item(569, 2147000570, 64967),
+    ]
+    spec = domain._x_mount_idmap("u", items)
+    assert spec == "u:0:2147000001:568 u:568:568:1 u:569:2147000570:64967"
+
+    spec_g = domain._x_mount_idmap("g", items[:1])
+    assert spec_g == "g:0:2147000001:568"

--- a/truenas_pylibvirt/domain/container/configuration.py
+++ b/truenas_pylibvirt/domain/container/configuration.py
@@ -6,14 +6,60 @@ from ..base.configuration import BaseDomainConfiguration
 
 @dataclass(kw_only=True)
 class ContainerIdmapConfigurationItem:
+    start: int
     target: int
     count: int
 
 
 @dataclass(kw_only=True)
 class ContainerIdmapConfiguration:
-    uid: ContainerIdmapConfigurationItem
-    gid: ContainerIdmapConfigurationItem
+    uid: list[ContainerIdmapConfigurationItem]
+    gid: list[ContainerIdmapConfigurationItem]
+
+    def __post_init__(self) -> None:
+        _validate_idmap_items("uid", self.uid)
+        _validate_idmap_items("gid", self.gid)
+
+
+def _validate_idmap_items(kind: str, items: list[ContainerIdmapConfigurationItem]) -> None:
+    """Reject idmap lists the kernel would refuse.
+
+    The Linux user namespace uid_map/gid_map interface (and the
+    X-mount.idmap mount option that mirrors it) requires non-overlapping
+    ranges on BOTH sides: no two entries may share a container-side UID,
+    and no two may share a host-side UID. The kernel enforces this at
+    namespace and idmapped-mount setup time; its errors there are opaque
+    (EINVAL, "operation not supported") and surface late, after libvirt
+    has already begun starting the domain.
+
+    Validating here surfaces the specific conflicting ranges so the
+    caller can diagnose the bad configuration without staring at a
+    libvirt stack trace.
+    """
+    if not items:
+        raise ValueError(f"At least one {kind} idmap entry is required")
+
+    for item in items:
+        if item.count <= 0:
+            raise ValueError(f"{kind} idmap entry count must be positive (got {item.count})")
+        if item.start < 0 or item.target < 0:
+            raise ValueError(f"{kind} idmap entry start/target must be non-negative")
+
+    sorted_by_ns = sorted(items, key=lambda i: i.start)
+    for prev, curr in zip(sorted_by_ns, sorted_by_ns[1:]):
+        if prev.start + prev.count > curr.start:
+            raise ValueError(
+                f"{kind} idmap container-side ranges overlap: "
+                f"[{prev.start}, {prev.start + prev.count}) and [{curr.start}, {curr.start + curr.count})"
+            )
+
+    sorted_by_host = sorted(items, key=lambda i: i.target)
+    for prev, curr in zip(sorted_by_host, sorted_by_host[1:]):
+        if prev.target + prev.count > curr.target:
+            raise ValueError(
+                f"{kind} idmap host-side ranges overlap: "
+                f"[{prev.target}, {prev.target + prev.count}) and [{curr.target}, {curr.target + curr.count})"
+            )
 
 
 class ContainerCapabilitiesPolicy(enum.Enum):

--- a/truenas_pylibvirt/domain/container/domain.py
+++ b/truenas_pylibvirt/domain/container/domain.py
@@ -29,13 +29,24 @@ class ContainerDomain(BaseDomain):
             idmapped_root = f"/run/truenas_containers/root/{self.configuration.uuid}"
             os.makedirs(idmapped_root, exist_ok=True)
 
+            idmap_spec = " ".join(
+                [
+                    self._x_mount_idmap("u", idmap.uid),
+                    self._x_mount_idmap("g", idmap.gid),
+                ]
+            )
             try:
-                subprocess.run([
-                    "mount",
-                    "-o", f"bind,X-mount.idmap=u:{self._x_mount_idmap(idmap.uid)} g:{self._x_mount_idmap(idmap.gid)}",
-                    self.configuration.root,
-                    idmapped_root,
-                ], capture_output=True, check=True)
+                subprocess.run(
+                    [
+                        "mount",
+                        "-o",
+                        f"bind,X-mount.idmap={idmap_spec}",
+                        self.configuration.root,
+                        idmapped_root,
+                    ],
+                    capture_output=True,
+                    check=True,
+                )
                 root = idmapped_root
                 # subprocess.run(["mount", "--make-rshared", idmapped_root], capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
@@ -60,18 +71,18 @@ class ContainerDomain(BaseDomain):
         pid_path = f"/var/run/libvirt/lxc/{self.configuration.uuid}.pid"
         with contextlib.suppress(FileNotFoundError):
             # Do not make a stat call to check if file exists or not
-            with open(pid_path, 'r') as f:
+            with open(pid_path, "r") as f:
                 pid = int(f.read())
 
-            with open(f'/proc/{pid}/task/{pid}/children') as f:
+            with open(f"/proc/{pid}/task/{pid}/children") as f:
                 return int(f.read().split()[0])
         return None
 
     def undefine(self, libvirt_domain: Any) -> None:
         libvirt_domain.undefine()
 
-    def _x_mount_idmap(self, item: ContainerIdmapConfigurationItem) -> str:
-        return f"0:{item.target}:{item.count}"
+    def _x_mount_idmap(self, prefix: str, items: list[ContainerIdmapConfigurationItem]) -> str:
+        return " ".join(f"{prefix}:{item.start}:{item.target}:{item.count}" for item in items)
 
 
 @dataclass

--- a/truenas_pylibvirt/domain/container/xml.py
+++ b/truenas_pylibvirt/domain/container/xml.py
@@ -65,10 +65,14 @@ class ContainerDomainXmlGenerator(BaseDomainXmlGenerator):
         ]
         # We will have to handle GPU's specially
         # For AMD case, we need to add /dev/kfd once even if multiple GPUs are being specified
-        if gpu_device := next((
-            device for device in self.domain.configuration.devices
-            if isinstance(device, GPUDevice) and device.gpu_type.lower() in ('amd', 'nvidia')
-        ), None):
+        if gpu_device := next(
+            (
+                device
+                for device in self.domain.configuration.devices
+                if isinstance(device, GPUDevice) and device.gpu_type.lower() in ("amd", "nvidia")
+            ),
+            None,
+        ):
             devices_xml.extend(gpu_device.gpu.driver_xml())
 
         return devices_xml
@@ -93,17 +97,29 @@ class ContainerDomainXmlGenerator(BaseDomainXmlGenerator):
         # which is the correct behavior for privileged containers (idmap=None).
         idmap = self.domain.configuration.idmap
         if idmap:
-            children.append(xml_element("idmap", children=[
-                xml_element("uid", attributes={
-                    "start": "0",
-                    "target": str(idmap.uid.target),
-                    "count": str(idmap.uid.count),
-                }),
-                xml_element("gid", attributes={
-                    "start": "0",
-                    "target": str(idmap.gid.target),
-                    "count": str(idmap.gid.count),
-                }),
-            ]))
+            idmap_children = []
+            for item in idmap.uid:
+                idmap_children.append(
+                    xml_element(
+                        "uid",
+                        attributes={
+                            "start": str(item.start),
+                            "target": str(item.target),
+                            "count": str(item.count),
+                        },
+                    )
+                )
+            for item in idmap.gid:
+                idmap_children.append(
+                    xml_element(
+                        "gid",
+                        attributes={
+                            "start": str(item.start),
+                            "target": str(item.target),
+                            "count": str(item.count),
+                        },
+                    )
+                )
+            children.append(xml_element("idmap", children=idmap_children))
 
         return children


### PR DESCRIPTION
uid/gid become lists; ContainerIdmapConfigurationItem gains a `start` field. The XML emitter produces one <uid>/<gid> element per entry, and the X-mount.idmap mount spec is built from space-separated prefix:start:target:count tokens. `__post_init__` rejects ranges that overlap on either the container or host side.

Enables per-account passthrough (e.g. apps UID 568 -> host 568) alongside the shifted base range, instead of one contiguous shift.