### PR TITLE
NAS-141095 / 26.0.0-RC.1 / Stage FilesystemDevice sources and reconcile runtime state (by Qubad786)

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,22 +11,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/truenas/middleware:26
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.13
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
-
-      - name: Install mypy
-        run: pip3 install mypy
-
-      - name: Clone and install truenas_pynetif
-        run: |
-          pip3 install https://github.com/truenas/truenas_pynetif/archive/master.zip
-
       - name: Test
         run: |
-          mypy truenas_pylibvirt/
+          PYTHONPATH=. mypy --strict truenas_pylibvirt/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,31 +9,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/truenas/middleware:26
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.13'
-
-    - name: Install system dependencies
+    - name: Test
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libvirt-dev libcap-dev pkg-config
-
-    - name: Clone and install truenas_pynetif
-      run: |
-        git clone https://github.com/truenas/truenas_pynetif.git
-        pip install -e truenas_pynetif/
-
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-test.txt
-        pip install -e .
-
-    - name: Run tests
-      run: |
-        pytest -v --tb=short tests/
+        PYTHONPATH=. pytest-3 -v --tb=short tests/

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Build-Depends: debhelper-compat (= 12),
                python3-libvirt,
                python3-pytest,
                python3-pyudev,
-               python3-truenas-pynetif
+               python3-truenas-pynetif,
+               python3-truenas-pyos
 Standards-Version: 4.4.1
 Homepage: https://github.com/truenas/truenas_pylibvirt
 
@@ -24,5 +25,6 @@ Depends: ${shlibs:Depends},
          ${python3:Depends},
          python3-libvirt,
          python3-pyudev,
-         python3-truenas-pynetif
+         python3-truenas-pynetif,
+         python3-truenas-pyos
 Description: Convenient wrapper for python3-libvirt

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,214 @@
+"""Tests for runtime state cleanup and reconciliation."""
+from __future__ import annotations
+
+import errno
+
+import pytest
+
+from truenas_pylibvirt import runtime
+
+
+def _enoent_umount(path: str, **kw: object) -> None:
+    """Simulates `umount(path)` when path does not exist."""
+    raise FileNotFoundError(errno.ENOENT, "No such file or directory", path)
+
+
+def _einval_umount(path: str, **kw: object) -> None:
+    """Simulates `umount(path)` when path exists but isn't a mountpoint."""
+    raise OSError(errno.EINVAL, "Invalid argument")
+
+
+@pytest.fixture
+def fake_state_dirs(tmp_path, monkeypatch):
+    """Redirect the runtime state roots to a tmp_path tree, and simulate
+    'path is not a mountpoint' for any umount call -- since the dirs we
+    create in tests are never real mounts. iter_mountinfo yields nothing
+    so reconcile doesn't pick up real system mounts."""
+    devices_root = tmp_path / "devices"
+    rootfs_root = tmp_path / "root"
+    devices_root.mkdir()
+    rootfs_root.mkdir()
+    monkeypatch.setattr(runtime, "DEVICES_RUNTIME_ROOT", str(devices_root))
+    monkeypatch.setattr(runtime, "ROOTFS_RUNTIME_ROOT", str(rootfs_root))
+    monkeypatch.setattr(runtime, "umount", _einval_umount)
+    monkeypatch.setattr(runtime, "iter_mountinfo", lambda **kw: iter(()))
+    return devices_root, rootfs_root
+
+
+def test_cleanup_for_uuid_noop_when_paths_missing(fake_state_dirs):
+    runtime.cleanup_for_uuid("does-not-exist")
+    devices_root, rootfs_root = fake_state_dirs
+    assert list(devices_root.iterdir()) == []
+    assert list(rootfs_root.iterdir()) == []
+
+
+def test_cleanup_for_uuid_removes_empty_dirs(fake_state_dirs):
+    """umount raises EINVAL (not a mount), function still rmdir's the dir."""
+    devices_root, rootfs_root = fake_state_dirs
+    (devices_root / "uuid-a" / "slug").mkdir(parents=True)
+    (rootfs_root / "uuid-a").mkdir()
+
+    runtime.cleanup_for_uuid("uuid-a")
+
+    assert not (devices_root / "uuid-a").exists()
+    assert not (rootfs_root / "uuid-a").exists()
+
+
+def test_cleanup_for_uuid_is_idempotent(fake_state_dirs):
+    devices_root, _ = fake_state_dirs
+    (devices_root / "uuid-a" / "slug").mkdir(parents=True)
+
+    runtime.cleanup_for_uuid("uuid-a")
+    runtime.cleanup_for_uuid("uuid-a")  # second call must not raise
+
+    assert not (devices_root / "uuid-a").exists()
+
+
+def test_cleanup_for_uuid_leaves_other_uuids_alone(fake_state_dirs):
+    devices_root, _ = fake_state_dirs
+    (devices_root / "uuid-a" / "slug").mkdir(parents=True)
+    (devices_root / "uuid-b" / "slug").mkdir(parents=True)
+
+    runtime.cleanup_for_uuid("uuid-a")
+
+    assert not (devices_root / "uuid-a").exists()
+    assert (devices_root / "uuid-b" / "slug").exists()
+
+
+def test_reconcile_keeps_active_removes_orphans(fake_state_dirs):
+    devices_root, rootfs_root = fake_state_dirs
+    (devices_root / "active-uuid" / "slug").mkdir(parents=True)
+    (devices_root / "orphan-uuid" / "slug").mkdir(parents=True)
+    (rootfs_root / "active-uuid").mkdir()
+    (rootfs_root / "orphan-uuid").mkdir()
+
+    runtime.reconcile({"active-uuid"})
+
+    assert (devices_root / "active-uuid" / "slug").exists()
+    assert (rootfs_root / "active-uuid").exists()
+    assert not (devices_root / "orphan-uuid").exists()
+    assert not (rootfs_root / "orphan-uuid").exists()
+
+
+def test_reconcile_handles_missing_base_dirs(tmp_path, monkeypatch):
+    """If neither base exists yet (fresh install), reconcile is a no-op."""
+    missing_devices = tmp_path / "missing-devices"
+    missing_rootfs = tmp_path / "missing-rootfs"
+    monkeypatch.setattr(runtime, "DEVICES_RUNTIME_ROOT", str(missing_devices))
+    monkeypatch.setattr(runtime, "ROOTFS_RUNTIME_ROOT", str(missing_rootfs))
+    monkeypatch.setattr(runtime, "iter_mountinfo", lambda **kw: iter(()))
+
+    runtime.reconcile({"any-uuid"})  # must not raise
+
+
+def test_reconcile_with_empty_active_set_cleans_everything(fake_state_dirs):
+    devices_root, rootfs_root = fake_state_dirs
+    (devices_root / "uuid-a" / "slug").mkdir(parents=True)
+    (rootfs_root / "uuid-b").mkdir()
+
+    runtime.reconcile(set())
+
+    assert not (devices_root / "uuid-a").exists()
+    assert not (rootfs_root / "uuid-b").exists()
+
+
+def test_reconcile_finds_orphan_via_mountinfo_when_dir_is_gone(
+    tmp_path, monkeypatch,
+):
+    """A mount that survives without its parent dir is detected via
+    iter_mountinfo and triggers cleanup_for_uuid for that UUID."""
+    devices_root = tmp_path / "devices"
+    rootfs_root = tmp_path / "root"
+    devices_root.mkdir()
+    rootfs_root.mkdir()
+    monkeypatch.setattr(runtime, "DEVICES_RUNTIME_ROOT", str(devices_root))
+    monkeypatch.setattr(runtime, "ROOTFS_RUNTIME_ROOT", str(rootfs_root))
+
+    stale_mountpoint = f"{devices_root}/ghost-uuid/%2Fmnt%2Fghost"
+    monkeypatch.setattr(
+        runtime, "iter_mountinfo",
+        lambda **kw: iter([{"mountpoint": stale_mountpoint}]),
+    )
+
+    calls: list[str] = []
+    monkeypatch.setattr(runtime, "cleanup_for_uuid", lambda u: calls.append(u))
+
+    runtime.reconcile(set())
+
+    assert "ghost-uuid" in calls
+
+
+def test_reconcile_ignores_unrelated_mountinfo_entries(
+    tmp_path, monkeypatch,
+):
+    devices_root = tmp_path / "devices"
+    rootfs_root = tmp_path / "root"
+    devices_root.mkdir()
+    rootfs_root.mkdir()
+    monkeypatch.setattr(runtime, "DEVICES_RUNTIME_ROOT", str(devices_root))
+    monkeypatch.setattr(runtime, "ROOTFS_RUNTIME_ROOT", str(rootfs_root))
+    monkeypatch.setattr(
+        runtime, "iter_mountinfo",
+        lambda **kw: iter([
+            {"mountpoint": "/"},
+            {"mountpoint": "/proc"},
+            {"mountpoint": "/mnt/tank"},
+            {"mountpoint": None},
+        ]),
+    )
+
+    calls: list[str] = []
+    monkeypatch.setattr(runtime, "cleanup_for_uuid", lambda u: calls.append(u))
+
+    runtime.reconcile(set())
+
+    assert calls == []
+
+
+def test_uuid_from_runtime_path():
+    assert runtime._uuid_from_runtime_path(
+        "/run/truenas_containers/devices/aaa/slug"
+    ) == "aaa"
+    assert runtime._uuid_from_runtime_path(
+        "/run/truenas_containers/root/bbb"
+    ) == "bbb"
+    assert runtime._uuid_from_runtime_path("/mnt/tank") is None
+    assert runtime._uuid_from_runtime_path("/run/truenas_containers/devices") is None
+
+
+def test_umount_and_rmdir_path_missing_is_noop(tmp_path, monkeypatch):
+    """umount raises FileNotFoundError -> function returns without rmdir."""
+    monkeypatch.setattr(runtime, "umount", _enoent_umount)
+    runtime.umount_and_rmdir(str(tmp_path / "never-existed"))
+
+
+def test_umount_and_rmdir_not_a_mount_still_rmdirs(tmp_path, monkeypatch):
+    """umount raises EINVAL (path exists, not a mount) -> rmdir runs."""
+    path = tmp_path / "stage"
+    path.mkdir()
+    monkeypatch.setattr(runtime, "umount", _einval_umount)
+
+    runtime.umount_and_rmdir(str(path))
+
+    assert not path.exists()
+
+
+def test_umount_and_rmdir_falls_back_to_detach_on_other_errors(tmp_path, monkeypatch):
+    """A non-EINVAL umount failure (e.g. EBUSY) triggers detach=True retry."""
+    path = tmp_path / "stage"
+    path.mkdir()
+
+    calls: list[dict] = []
+
+    def fake_umount(p, **kw):
+        calls.append({"path": p, **kw})
+        if not kw.get("detach"):
+            raise OSError(errno.EBUSY, "Device or resource busy")
+
+    monkeypatch.setattr(runtime, "umount", fake_umount)
+
+    runtime.umount_and_rmdir(str(path))
+
+    assert len(calls) == 2
+    assert calls[0] == {"path": str(path)}
+    assert calls[1] == {"path": str(path), "detach": True}

--- a/truenas_pylibvirt/device/filesystem.py
+++ b/truenas_pylibvirt/device/filesystem.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import contextlib
 import os
+import urllib.parse
 from dataclasses import dataclass
+from typing import Generator, TYPE_CHECKING
 from xml.etree import ElementTree
 
+import truenas_os
+
 from .base import Device, DeviceXmlContext
+from ..error import Error
+from ..runtime import DEVICES_RUNTIME_ROOT, umount_and_rmdir
 from ..xml import xml_element
+
+if TYPE_CHECKING:
+    from ..libvirtd.connection import Connection
 
 
 @dataclass(kw_only=True)
@@ -25,6 +35,97 @@ class FilesystemDevice(Device):
                 ],
             ),
         ]
+
+    @contextlib.contextmanager
+    def run(
+        self, connection: "Connection", domain_uuid: str,
+    ) -> Generator[None, None, None]:
+        # Stage a host-side, non-recursive clone of `self.source` onto a
+        # per-device path under /run, with slave propagation, then redirect
+        # `self.source` to that staged path so xml() emits it.
+        #
+        # libvirt-LXC hard-codes a non-recursive MS_BIND for FILESYSTEM
+        # devices (src/lxc/lxc_container.c:lxcContainerMountFSBind) and runs
+        # it inside the container's user namespace. If the user-supplied
+        # source has nested submounts -- typical for a ZFS parent dataset
+        # with auto-mounted children -- the kernel's has_locked_children
+        # check in fs/namespace.c:__do_loopback rejects the bind with
+        # EINVAL because those children propagated into the less-privileged
+        # userns are marked locked (kernel commit 5ff9d8a65ce8). Staging
+        # here, as host root in init_user_ns, gives libvirt a single flat
+        # mount with no children.
+        #
+        # As a side effect this also fixes ENOENT path-traversal failures
+        # when the user's source has a restrictive parent ACL, because the
+        # mapped UID's access check now runs against a middleware-owned
+        # /run path.
+        #
+        # Implementation: open_tree(OPEN_TREE_CLONE) clones the source mount
+        # as a detached tree, mount_setattr applies MS_SLAVE propagation
+        # while detached, and move_mount attaches the clone at staged_path.
+        # Applying propagation before attach closes the window the old
+        # `mount --bind` + `mount --make-rslave` pair had, where the staged
+        # mount briefly inherited shared propagation from the source.
+        # AT_RECURSIVE on mount_setattr is a no-op today (the clone is
+        # non-recursive, no children) but auto-covers children if the clone
+        # ever switches to OPEN_TREE_CLONE | AT_RECURSIVE.
+        #
+        # The finally below only undoes this device's own staging. The
+        # per-uuid parent dir and any leftovers across a middleware restart
+        # are reaped by truenas_pylibvirt.runtime.cleanup_for_uuid, called
+        # from DomainManager's STOPPED/UNDEFINED event callback.
+        original_source = self.source
+        staged_path = os.path.join(
+            DEVICES_RUNTIME_ROOT, domain_uuid, self._staging_slug(),
+        )
+
+        os.makedirs(staged_path, mode=0o755, exist_ok=True)
+
+        fd: int | None = None
+        attached = False
+        try:
+            fd = truenas_os.open_tree(
+                path=original_source,
+                flags=truenas_os.OPEN_TREE_CLONE | truenas_os.OPEN_TREE_CLOEXEC,
+            )
+            truenas_os.mount_setattr(
+                path="",
+                dirfd=fd,
+                propagation=truenas_os.MS_SLAVE,
+                flags=truenas_os.AT_EMPTY_PATH | truenas_os.AT_RECURSIVE,
+            )
+            truenas_os.move_mount(
+                from_path="",
+                from_dirfd=fd,
+                to_path=staged_path,
+                flags=truenas_os.MOVE_MOUNT_F_EMPTY_PATH,
+            )
+            attached = True
+        except OSError as e:
+            raise Error(
+                f"Unable to stage filesystem device {self.identity()!r}: {e}"
+            ) from None
+        finally:
+            if fd is not None:
+                os.close(fd)
+            if not attached:
+                self._cleanup_self_stage(staged_path)
+
+        self.source = staged_path
+        try:
+            yield
+        finally:
+            self.source = original_source
+            self._cleanup_self_stage(staged_path)
+
+    def _staging_slug(self) -> str:
+        return urllib.parse.quote(self.target, safe='')
+
+    @staticmethod
+    def _cleanup_self_stage(staged_path: str) -> None:
+        # Best-effort: only undo this device's own mount + dir. The per-uuid
+        # parent dir is left for runtime.cleanup_for_uuid to reap centrally.
+        umount_and_rmdir(staged_path)
 
     def identity_impl(self) -> str:
         return f'{self.source}:{self.target}'

--- a/truenas_pylibvirt/domain/container/domain.py
+++ b/truenas_pylibvirt/domain/container/domain.py
@@ -7,6 +7,7 @@ import pathlib
 import subprocess
 from typing import Any, Generator
 
+from ... import runtime
 from ...error import Error
 from ..base.domain import BaseDomain
 from .configuration import ContainerDomainConfiguration, ContainerIdmapConfigurationItem
@@ -26,7 +27,7 @@ class ContainerDomain(BaseDomain):
             # Prevent `Failure in libvirt_lxc startup: Failed to create /mnt/tank/container/.oldroot: Permission denied`
             (pathlib.Path(self.configuration.root) / ".oldroot").mkdir(mode=0o0755, exist_ok=True)
 
-            idmapped_root = f"/run/truenas_containers/root/{self.configuration.uuid}"
+            idmapped_root = os.path.join(runtime.ROOTFS_RUNTIME_ROOT, self.configuration.uuid)
             os.makedirs(idmapped_root, exist_ok=True)
 
             idmap_spec = " ".join(
@@ -50,6 +51,9 @@ class ContainerDomain(BaseDomain):
                 root = idmapped_root
                 # subprocess.run(["mount", "--make-rshared", idmapped_root], capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
+                # Symmetric with FilesystemDevice's failure path: leave no
+                # half-created dir for the startup reconcile to mop up.
+                runtime.cleanup_for_uuid(self.configuration.uuid)
                 raise Error(
                     f"Unable to set up idmapped root: {e.cmd} returned code {e.returncode}:\n{e.stderr.strip()}"
                 ) from None
@@ -58,14 +62,12 @@ class ContainerDomain(BaseDomain):
             yield ContainerDomainContext(root=root)
         finally:
             if idmapped_root is not None:
-                try:
-                    subprocess.run(["umount", idmapped_root], capture_output=True, check=True)
-                except subprocess.CalledProcessError as e:
-                    raise Error(
-                        f"Unable to umount idmapped root: {e.cmd} returned code {e.returncode}:\n{e.stderr.strip()}"
-                    ) from None
-
-                os.rmdir(idmapped_root)
+                # Best-effort. The authoritative reconciler is
+                # runtime.cleanup_for_uuid (called from the STOPPED event
+                # callback in DomainManager), so a failure here must not
+                # raise -- otherwise it would mask a more interesting
+                # upstream error and prevent siblings' cleanup.
+                runtime.umount_and_rmdir(idmapped_root)
 
     def pid(self) -> int | None:
         pid_path = f"/var/run/libvirt/lxc/{self.configuration.uuid}.pid"

--- a/truenas_pylibvirt/domain/manager.py
+++ b/truenas_pylibvirt/domain/manager.py
@@ -7,6 +7,7 @@ import time
 from typing import Any
 from xml.etree import ElementTree
 
+from .. import runtime
 from ..error import Error, DomainDoesNotExistError
 from ..libvirtd.connection import Connection, DomainEvent, DomainState, VirDomainEvent
 from .base.domain import BaseDomain
@@ -159,6 +160,26 @@ class DomainManager:
             return
 
         if event.event in STOPPED_EVENTS:
+            # Happy path: contextmanagers unwind first and undo their own
+            # per-device staging. Wrapped because one device's cleanup
+            # failing must not block the runtime sweep below.
             with self.started_domains_lock:
                 if started_domain := self.started_domains.pop(event.uuid, None):
-                    started_domain.cleanup()
+                    try:
+                        started_domain.cleanup()
+                    except Exception:
+                        logger.exception(
+                            "StartedDomain cleanup failed for uuid %s; "
+                            "runtime sweep will reconcile",
+                            event.uuid,
+                        )
+
+                # Authoritative reconciliation of durable runtime state.
+                # Independent of `started_domains`, which is empty after a
+                # middleware restart even when libvirt-managed containers are
+                # still running. Harmless for VMs: no `/run/truenas_containers/*`
+                # entries match their UUIDs, so this is a no-op.
+                try:
+                    runtime.cleanup_for_uuid(event.uuid)
+                except Exception:
+                    logger.exception("Runtime state cleanup failed for uuid %s", event.uuid)

--- a/truenas_pylibvirt/domain/managers.py
+++ b/truenas_pylibvirt/domain/managers.py
@@ -1,3 +1,4 @@
+from .. import runtime
 from .manager import DomainManager
 from ..libvirtd.connection_manager import ConnectionManager
 
@@ -23,3 +24,19 @@ class DomainManagers:
 
         self.vms_connection = self.connection_manager.create(vms_uri)
         self.vms = DomainManager(self.vms_connection)
+
+    def reconcile_runtime_state(self) -> None:
+        # Sweep /run/truenas_containers/* for per-uuid trees that don't
+        # correspond to an active libvirt domain. Call once at process
+        # startup, after libvirt connections are reachable.
+        #
+        # Aggregation across both managers is required: per-uuid runtime
+        # state is container-only, but if we reconciled per-manager the
+        # VM manager would see container UUIDs as "not in my active set"
+        # and wrongly clean them.
+        active: set[str] = set()
+        for manager in (self.containers, self.vms):
+            for domain in manager.connection.list_domains():
+                if domain.isActive():
+                    active.add(domain.name())
+        runtime.reconcile(active)

--- a/truenas_pylibvirt/runtime.py
+++ b/truenas_pylibvirt/runtime.py
@@ -1,0 +1,134 @@
+"""Cleanup and reconciliation of durable runtime state under /run/truenas_containers/.
+
+The container start path stages host-side bind mounts for FilesystemDevice
+sources and for the idmap rootfs. Those mounts are durable: they survive a
+middleware crash/restart. The Python contextmanager that created them is
+in-memory and does not. This module owns reconciling that durable state.
+
+Three call sites use it:
+
+1. FilesystemDevice.run() / ContainerDomain.run() finally blocks -- fast
+   happy-path cleanup during a normal stop.
+2. DomainManager's STOPPED/UNDEFINED event callback -- authoritative
+   cleanup that runs even after a middleware restart, when the in-memory
+   started_domains dict is empty.
+3. DomainManagers.reconcile_runtime_state() -- one-shot startup sweep.
+
+Mount/umount goes through truenas_os_pyutils.mount.umount (kernel umount2
+syscall, with MNT_DETACH fallback on real umount failures). No subprocess
+shell-out.
+
+All entry points are idempotent: safe to call repeatedly, safe to call on
+UUIDs that have no state, safe to call alongside a freshly starting
+container provided the caller passes that UUID in the active set.
+"""
+from __future__ import annotations
+
+import contextlib
+import errno
+import logging
+import os
+
+from truenas_os_pyutils.mount import iter_mountinfo, umount
+
+
+logger = logging.getLogger(__name__)
+
+
+CONTAINERS_RUNTIME_ROOT = "/run/truenas_containers"
+DEVICES_RUNTIME_ROOT = os.path.join(CONTAINERS_RUNTIME_ROOT, "devices")
+ROOTFS_RUNTIME_ROOT = os.path.join(CONTAINERS_RUNTIME_ROOT, "root")
+
+
+def cleanup_for_uuid(uuid: str) -> None:
+    """Remove every durable runtime artifact for `uuid`. Idempotent."""
+    _cleanup_devices_for_uuid(uuid)
+    _cleanup_rootfs_for_uuid(uuid)
+
+
+def reconcile(active_uuids: set[str]) -> None:
+    """Sweep runtime state; clean any per-uuid entry not in `active_uuids`.
+
+    Scans both /proc/self/mountinfo (catches mounts whose backing dir was
+    removed) and the directory tree (catches empty per-uuid dirs left
+    behind by a partially-cleaned shutdown). The union is the set of UUIDs
+    needing cleanup.
+    """
+    orphan_uuids: set[str] = set()
+
+    for mount in iter_mountinfo():
+        mountpoint = mount.get("mountpoint")
+        if not isinstance(mountpoint, str):
+            continue
+        uuid = _uuid_from_runtime_path(mountpoint)
+        if uuid is None or uuid in active_uuids:
+            continue
+        orphan_uuids.add(uuid)
+
+    for base in (DEVICES_RUNTIME_ROOT, ROOTFS_RUNTIME_ROOT):
+        try:
+            with os.scandir(base) as it:
+                for entry in it:
+                    if entry.name not in active_uuids:
+                        orphan_uuids.add(entry.name)
+        except FileNotFoundError:
+            continue
+
+    for uuid in orphan_uuids:
+        logger.info("Reconciling orphaned runtime state for uuid %s", uuid)
+        cleanup_for_uuid(uuid)
+
+
+def umount_and_rmdir(path: str) -> None:
+    """Idempotent umount-then-rmdir for a single staged path.
+
+    Lets the kernel be the source of truth: a single umount2() call signals
+    "path doesn't exist" (FileNotFoundError), "path isn't a mountpoint"
+    (EINVAL), or some real busy/IO failure -- each routed accordingly.
+    Pre-checking with os.path.exists + statx would just add TOCTOU windows
+    and duplicate syscalls. All failures are best-effort: the caller is one
+    of three independent cleanup layers, so a stuck mount here gets a
+    retry from the next.
+    """
+    try:
+        umount(path)
+    except FileNotFoundError:
+        return
+    except OSError as e:
+        if e.errno != errno.EINVAL:
+            logger.warning(
+                "Plain umount of %s failed (%s); falling back to MNT_DETACH",
+                path,
+                e,
+            )
+            with contextlib.suppress(OSError):
+                umount(path, detach=True)
+    with contextlib.suppress(OSError):
+        os.rmdir(path)
+
+
+def _uuid_from_runtime_path(path: str) -> str | None:
+    """Extract <uuid> from /run/truenas_containers/{devices,root}/<uuid>[/...]."""
+    for base in (DEVICES_RUNTIME_ROOT, ROOTFS_RUNTIME_ROOT):
+        prefix = base + os.sep
+        if path.startswith(prefix):
+            remainder = path[len(prefix):]
+            uuid = remainder.split(os.sep, 1)[0]
+            return uuid or None
+    return None
+
+
+def _cleanup_devices_for_uuid(uuid: str) -> None:
+    per_uuid = os.path.join(DEVICES_RUNTIME_ROOT, uuid)
+    try:
+        with os.scandir(per_uuid) as it:
+            for entry in it:
+                umount_and_rmdir(entry.path)
+    except FileNotFoundError:
+        return
+    with contextlib.suppress(OSError):
+        os.rmdir(per_uuid)
+
+
+def _cleanup_rootfs_for_uuid(uuid: str) -> None:
+    umount_and_rmdir(os.path.join(ROOTFS_RUNTIME_ROOT, uuid))


### PR DESCRIPTION
### Problem

Filesystem devices on **unprivileged** containers fail to start when the host source has nested mounts beneath it — typically a ZFS parent dataset with auto-mounted child datasets. libvirt-LXC startup aborts with:

```text
internal error: guest failed to start: Failure in libvirt_lxc startup: Failed to bind mount directory /.oldroot/mnt/tank/<dataset> to /mnt/<dataset>: Invalid argument
```

**Mechanism.** libvirt-LXC performs a non-recursive `MS_BIND` for `<filesystem type='mount'>` devices inside the container's user namespace (`src/lxc/lxc_container.c:lxcContainerMountFSBind`, hard-coded — no XML knob to enable `MS_REC`). The host's child mounts propagate into the less-privileged userns via shared propagation; the kernel marks them **locked** to prevent the unprivileged userns from un-hiding them (kernel commit `5ff9d8a65ce8`). When libvirt then tries the non-recursive bind, `fs/namespace.c:__do_loopback`'s `has_locked_children()` check rejects it with `EINVAL`.

The locked children are still **visible** inside the container — they're just immovable. The failure is in the bind syscall, not in mount visibility.

### Solution

Host-stage each FilesystemDevice source on a per-device path before libvirt sees it. In `FilesystemDevice.run()`, executed as host root in `init_user_ns`:

1. `truenas_os.open_tree(<source>, OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC)` clones the source mount as a detached tree — non-recursive, so the staged tree is a single flat mount with no children. libvirt's later non-recursive bind has nothing locked to trip over.
2. `truenas_os.mount_setattr(propagation=MS_SLAVE, flags=AT_RECURSIVE)` on the detached clone — applied **before** attach, so the staged mount is never in the source's shared peer group. A container-side umount cannot leak back. Matches Incus's `MS_REC|MS_SLAVE` pattern in `DiskMount` (`internal/server/device/device_utils_disk.go`).
3. `truenas_os.move_mount` attaches the clone at `/run/truenas_containers/devices/<uuid>/<urlquoted target>`, and `self.source` is rewritten to the staged path so `xml()` emits it to libvirt.

Trade-off: nested child datasets are not visible inside the container under the staged mount. This is forced by libvirt-LXC's hard-coded non-recursive `MS_BIND` and applies regardless of the host-side bind flavour — confirmed against upstream `src/lxc/lxc_container.c`, `src/conf/schemas/domaincommon.rng`, and `struct _virDomainFSDef` in `src/conf/domain_conf.h`. Recursive exposure would require a libvirt upstream change.

### Hardening: durable runtime state cleanup

Both the new device staging path and the pre-existing rootfs idmap path at `/run/truenas_containers/root/<uuid>` are durable state on the host: they survive a `middlewared` crash or restart. Cleanup used to hang off Python contextmanagers tied to in-memory `DomainManager.started_domains`, which is empty after a restart. Result: any restart-then-stop sequence leaked mounts and per-uuid directories under `/run/truenas_containers/*`.

New `truenas_pylibvirt/runtime.py` owns reconciliation, used from three independent layers:

1. `FilesystemDevice.run()` / `ContainerDomain.run()` `finally` blocks — fast happy-path cleanup during a normal stop.
2. `DomainManager._domain_event_callback` — on `STOPPED`/`UNDEFINED` events, calls `runtime.cleanup_for_uuid` unconditionally, independent of `started_domains` membership. Recovers from the middleware-restart case.
3. `DomainManagers.reconcile_runtime_state()` — startup sweep that finds orphaned UUIDs via `iter_mountinfo` (catches mounts whose backing directory was removed) and `os.scandir` (catches empty per-uuid dirs).

Mount setup and umount go through `truenas_os` syscall wrappers (`open_tree`, `mount_setattr`, `move_mount`, `umount2`) — no subprocess shell-out. Same convention as `middleware/.../plugins/sysdataset.py:_bind_cores_to_coredump`. `umount_and_rmdir` lets the kernel be the source of truth: `FileNotFoundError` (path missing) and `OSError(EINVAL)` (not a mountpoint) are distinguished from real failures, which fall back to `MNT_DETACH`.

`ContainerDomain.run()` also adopts the central cleanup for its idmap rootfs: failure path calls `runtime.cleanup_for_uuid` symmetrically with `FilesystemDevice`; `finally` block delegates to `runtime.umount_and_rmdir` so a stuck umount no longer raises and masks the upstream error.

### References

* [Linux kernel: lock in place mounts from more privileged users (5ff9d8a65ce8)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5ff9d8a65ce8) — origin of `has_locked_children` behaviour.
* `fs/namespace.c:__do_loopback` — site of the `EINVAL` rejection.
* `libvirt/src/lxc/lxc_container.c:lxcContainerMountFSBind` — the non-recursive `MS_BIND` call inside the container userns.
* Incus `internal/server/device/device_utils_disk.go:DiskMount` — same host-staging pattern (non-recursive bind + recursive slave) for the same class of bug.


Original PR: https://github.com/truenas/truenas_pylibvirt/pull/49
