### PR TITLE
NAS-141465 / 27.0.0-BETA.1 / Add aarch64 guest VM support

### DIFF
--- a/tests/domain/test_vm_xml.py
+++ b/tests/domain/test_vm_xml.py
@@ -1,0 +1,108 @@
+"""Tests for VM XML generation."""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from truenas_pylibvirt.domain.vm.xml import VmDomainXmlGenerator
+
+
+def _generator(
+    arch_type: str | None = None,
+    *,
+    hide_from_msr: bool = False,
+    hyperv_enlightenments: bool = False,
+    enable_secure_boot: bool = False,
+    trusted_platform_module: bool = False,
+    tpm_path: str = '/tmp/tpm',
+    ensure_display_device: bool = False,
+    devices: list | None = None,
+    min_memory: int | None = None,
+) -> VmDomainXmlGenerator:
+    config = Mock()
+    config.arch_type = arch_type
+    config.hide_from_msr = hide_from_msr
+    config.hyperv_enlightenments = hyperv_enlightenments
+    config.enable_secure_boot = enable_secure_boot
+    config.trusted_platform_module = trusted_platform_module
+    config.tpm_path = tpm_path
+    config.ensure_display_device = ensure_display_device
+    config.devices = devices if devices is not None else []
+    config.min_memory = min_memory
+    domain = Mock()
+    domain.configuration = config
+    gen = VmDomainXmlGenerator.__new__(VmDomainXmlGenerator)
+    gen.domain = domain
+    return gen
+
+
+@pytest.mark.parametrize("kvm,host_arch,guest_arch,expected", [
+    # /dev/kvm absent -- always TCG
+    (False, "x86_64",  None,       "qemu"),
+    (False, "x86_64",  "x86_64",   "qemu"),
+    (False, "aarch64", "aarch64",  "qemu"),
+    # arch_type unset -- host arch implied, KVM
+    (True,  "x86_64",  None,       "kvm"),
+    (True,  "aarch64", None,       "kvm"),
+    # Same arch -- KVM
+    (True,  "x86_64",  "x86_64",   "kvm"),
+    (True,  "aarch64", "aarch64",  "kvm"),
+    # 32-bit x86 guest on 64-bit x86 host -- KVM accelerates this
+    (True,  "x86_64",  "i686",     "kvm"),
+    (True,  "x86_64",  "i386",     "kvm"),
+    # Cross-arch -- TCG
+    (True,  "x86_64",  "aarch64",  "qemu"),
+    (True,  "aarch64", "x86_64",   "qemu"),
+    (True,  "aarch64", "i686",     "qemu"),
+])
+def test_type_decision(kvm, host_arch, guest_arch, expected):
+    """_type() picks kvm for same-arch (or x86 family) when KVM available, qemu otherwise."""
+    gen = _generator(guest_arch)
+    with patch("truenas_pylibvirt.domain.vm.xml.kvm_supported", return_value=kvm), \
+         patch("truenas_pylibvirt.domain.vm.xml.platform.machine", return_value=host_arch):
+        assert gen._type() == expected
+
+
+@pytest.mark.parametrize("arch_type,hide,hyperv,secboot,expected_tags", [
+    # x86 baseline (arch_type unset -> defaults to x86_64)
+    (None,      False, False, False, ["acpi", "apic", "msrs"]),
+    ("x86_64",  False, False, False, ["acpi", "apic", "msrs"]),
+    ("i686",    False, False, False, ["acpi", "apic", "msrs"]),
+    # x86 with each flag toggled
+    ("x86_64",  True,  False, False, ["acpi", "apic", "msrs", "kvm"]),
+    ("x86_64",  False, True,  False, ["acpi", "apic", "msrs", "hyperv"]),
+    ("x86_64",  False, False, True,  ["acpi", "apic", "msrs", "smm"]),
+    ("x86_64",  True,  True,  True,  ["acpi", "apic", "msrs", "kvm", "hyperv", "smm"]),
+    # aarch64 emits only <acpi>; x86-only flags are silently dropped at emission
+    # (validation tightening is a separate concern). Secure boot on aarch64 is
+    # signaled via <loader secure='yes'/> in _os_xml(), not <smm>.
+    ("aarch64", False, False, False, ["acpi"]),
+    ("aarch64", True,  False, False, ["acpi"]),
+    ("aarch64", False, True,  False, ["acpi"]),
+    ("aarch64", False, False, True,  ["acpi"]),
+    ("aarch64", True,  True,  True,  ["acpi"]),
+])
+def test_features_xml_children(arch_type, hide, hyperv, secboot, expected_tags):
+    """aarch64 emits only <acpi>; x86 emits the full set, flags toggle extra elements."""
+    gen = _generator(
+        arch_type,
+        hide_from_msr=hide,
+        hyperv_enlightenments=hyperv,
+        enable_secure_boot=secboot,
+    )
+    assert [f.tag for f in gen._features_xml_children()] == expected_tags
+
+
+@pytest.mark.parametrize("arch_type,expected_model", [
+    (None,      "tpm-crb"),  # default arch = x86_64
+    ("x86_64",  "tpm-crb"),
+    ("i686",    "tpm-crb"),
+    ("aarch64", "tpm-tis"),  # libvirt model name; libvirt emits qemu's tpm-tis-device for it
+])
+def test_tpm_model(arch_type, expected_model):
+    """TPM device model: tpm-crb on x86 (LPC bus); tpm-tis-device on aarch64 (memory-mapped)."""
+    gen = _generator(arch_type, trusted_platform_module=True)
+    tpm_elements = [d for d in gen._devices_xml_children() if d.tag == "tpm"]
+    assert len(tpm_elements) == 1
+    assert tpm_elements[0].attrib["model"] == expected_model

--- a/tests/utils/test_ovmf.py
+++ b/tests/utils/test_ovmf.py
@@ -97,6 +97,58 @@ def mock_exists_factory(existing_files: set[str]):
         set(),
         None,
     ),
+    # AAVMF: plain CODE -> plain VARS
+    (
+        'AAVMF_CODE.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.fd',
+    ),
+    # AAVMF: no-secboot CODE -> plain VARS (the "no-" must not trip secboot detection)
+    (
+        'AAVMF_CODE.no-secboot.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.fd',
+    ),
+    # AAVMF: ms CODE -> ms VARS
+    (
+        'AAVMF_CODE.ms.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd', '/usr/share/AAVMF/AAVMF_VARS.ms.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.ms.fd',
+    ),
+    # AAVMF: secboot CODE -> ms VARS
+    (
+        'AAVMF_CODE.secboot.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd', '/usr/share/AAVMF/AAVMF_VARS.ms.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.ms.fd',
+    ),
+    # AAVMF: secboot.strictnx CODE -> ms VARS
+    (
+        'AAVMF_CODE.secboot.strictnx.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd', '/usr/share/AAVMF/AAVMF_VARS.ms.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.ms.fd',
+    ),
+    # AAVMF: snakeoil CODE -> snakeoil VARS
+    (
+        'AAVMF_CODE.snakeoil.fd',
+        {
+            '/usr/share/AAVMF/AAVMF_VARS.fd',
+            '/usr/share/AAVMF/AAVMF_VARS.ms.fd',
+            '/usr/share/AAVMF/AAVMF_VARS.snakeoil.fd',
+        },
+        '/usr/share/AAVMF/AAVMF_VARS.snakeoil.fd',
+    ),
+    # AAVMF: snakeoil fallback to ms when snakeoil VARS missing
+    (
+        'AAVMF_CODE.snakeoil.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd', '/usr/share/AAVMF/AAVMF_VARS.ms.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.ms.fd',
+    ),
+    # AAVMF: secboot fallback to plain when ms VARS missing
+    (
+        'AAVMF_CODE.secboot.fd',
+        {'/usr/share/AAVMF/AAVMF_VARS.fd'},
+        '/usr/share/AAVMF/AAVMF_VARS.fd',
+    ),
     # Invalid filename returns None
     (
         'some_other_file.fd',

--- a/truenas_pylibvirt/domain/vm/xml.py
+++ b/truenas_pylibvirt/domain/vm/xml.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import platform
 import shlex
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
 from ...device.display import DisplayDevice, DisplayDeviceType
+from ...utils import kvm_supported
 from ...xml import xml_element
 from ..base.xml import BaseDomainXmlGenerator
 from .configuration import VmBootloader, VmCpuMode
 from ...utils.cpu import get_cpu_model_choices
-from ...utils.ovmf import get_ovmf_vars_file
+from ...utils.ovmf import AAVMF_DIR, OVMF_DIR, get_ovmf_vars_file
 
 if TYPE_CHECKING:
     from .domain import VmDomain
@@ -20,7 +22,18 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
     domain: VmDomain
 
     def _type(self) -> str:
-        return "kvm"
+        if not kvm_supported():
+            return "qemu"
+        guest_arch = self.domain.configuration.arch_type
+        if not guest_arch:
+            return "kvm"
+        host_arch = platform.machine()
+        if guest_arch == host_arch:
+            return "kvm"
+        # KVM-x86 accelerates 32-bit guests on 64-bit hosts
+        if host_arch == "x86_64" and guest_arch in ("i686", "i386"):
+            return "kvm"
+        return "qemu"
 
     def _os_xml(self) -> ElementTree.Element:
         hvm_attributes = {}
@@ -38,15 +51,21 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
         ]
 
         if self.domain.configuration.bootloader == VmBootloader.UEFI:
+            bootloader_ovmf = self.domain.configuration.bootloader_ovmf
+            is_aarch64 = bootloader_ovmf.startswith('AAVMF_CODE')
+            firmware_dir = AAVMF_DIR if is_aarch64 else OVMF_DIR
+            # secure='yes' is the x86 SMM-based secure-boot signal -- libvirt
+            # only accepts it on q35 machines. On aarch64, secure boot is
+            # enforced by the AAVMF firmware variant itself (AAVMF_CODE.ms.fd
+            # etc.), so we omit the attribute.
+            loader_attrs = {"readonly": "yes", "type": "pflash"}
+            if not is_aarch64:
+                loader_attrs["secure"] = "yes" if self.domain.configuration.enable_secure_boot else "no"
             children.extend([
                 xml_element(
                     "loader",
-                    attributes={
-                        "readonly": "yes",
-                        "secure": "yes" if self.domain.configuration.enable_secure_boot else "no",
-                        "type": "pflash",
-                    },
-                    text=f"/usr/share/OVMF/{self.domain.configuration.bootloader_ovmf}",
+                    attributes=loader_attrs,
+                    text=f"{firmware_dir}/{bootloader_ovmf}",
                 ),
                 xml_element(
                     "nvram",
@@ -75,7 +94,8 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
         ))
 
         if self.domain.configuration.cpu_mode == VmCpuMode.CUSTOM:
-            if (model := self.domain.configuration.cpu_model) and model in get_cpu_model_choices():
+            arch = self.domain.configuration.arch_type or 'x86_64'
+            if (model := self.domain.configuration.cpu_model) and model in get_cpu_model_choices().get(arch, {}):
                 # Right now this is best effort for the domain to start with specified CPU Model and not fallback
                 # However if some features are missing in the host, qemu will right now still start the domain
                 # and mark them as missing. We should perhaps make this configurable in the future to control
@@ -176,9 +196,14 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
             ))
 
         if self.domain.configuration.trusted_platform_module:
+            # tpm-crb sits on x86's LPC bus; the aarch64 virt machine has no LPC.
+            # libvirt's model attribute accepts 'tpm-tis' for aarch64; libvirt
+            # translates it to qemu's tpm-tis-device when emitting the cmdline.
+            arch_type = self.domain.configuration.arch_type or 'x86_64'
+            tpm_model = 'tpm-tis' if arch_type == 'aarch64' else 'tpm-crb'
             children.append(xml_element(
                 "tpm",
-                attributes={"model": "tpm-crb"},
+                attributes={"model": tpm_model},
                 children=[
                     xml_element(
                         "backend", attributes={"type": "emulator", "version": "2.0", "persistent_state": "yes"},
@@ -210,6 +235,14 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
         return list(children)
 
     def _features_xml_children(self) -> list[ElementTree.Element]:
+        arch_type = self.domain.configuration.arch_type or 'x86_64'
+
+        # aarch64 (virt) accepts <acpi/> but rejects x86-specific feature elements
+        # (<apic>, <msrs>, <kvm><hidden>, <hyperv>, <smm>). Secure boot on aarch64
+        # is signaled via <loader secure='yes'/> in _os_xml(), not via <smm>.
+        if arch_type == 'aarch64':
+            return [xml_element("acpi")]
+
         features = [
             xml_element("acpi"),
             xml_element("apic"),

--- a/truenas_pylibvirt/utils/cpu.py
+++ b/truenas_pylibvirt/utils/cpu.py
@@ -4,27 +4,42 @@ import os
 from xml.etree import ElementTree as etree
 
 
+# Translate libvirt cpu_map architecture names to TrueNAS arch_type values.
+# Each libvirt arch maps to one or more TrueNAS arch_type values that share
+# its CPU model set (e.g. x86_64 and i686 both consume libvirt's x86 models;
+# libvirt's arm cpu_map ships only 64-bit cores so it maps to aarch64 only).
+_ARCH_MAP = {
+    'x86':   ('x86_64', 'i686'),
+    'ppc64': ('ppc64',),
+    'arm':   ('aarch64',),
+}
+
+
 @functools.cache
-def get_cpu_model_choices() -> dict[str, str]:
+def get_cpu_model_choices() -> dict[str, dict[str, str]]:
     """
-    Parse CPU model choices from libvirt XML files.
+    Parse CPU model choices from libvirt XML files, grouped by guest arch.
     This function is cached to avoid re-parsing XML files on every call.
-    Returns a dict of {model_name: model_name} for available CPU models.
+    Returns a dict of {arch_type: {model_name: model_name}} where arch_type
+    matches TrueNAS VM arch_type values (e.g. 'x86_64', 'i686', 'aarch64',
+    'ppc64'). Architectures absent from libvirt's cpu_map (e.g. 32-bit ARM)
+    are also absent from the result.
     """
     base_path = '/usr/share/libvirt/cpu_map'
     index_file = os.path.join(base_path, 'index.xml')
     with open(index_file, 'r') as f:
         index_xml = etree.fromstring(f.read().strip())
 
-    models = {}
+    result: dict[str, dict[str, str]] = {}
 
-    # Process architectures that virsh cpu-models supports
-    # Note: arm is excluded as virsh cpu-models arm fails
+    # Process architectures whose cpu_map XML files we parse
     for arch in index_xml.findall('.//arch[@name]'):
         arch_name = arch.get('name')
-        if arch_name not in ['x86', 'ppc64']:
+        truenas_archs = _ARCH_MAP.get(arch_name)
+        if truenas_archs is None:
             continue
 
+        models: dict[str, str] = {}
         # Process all include elements in the architecture
         for elem in arch.iter('include'):
             filename = elem.get('filename')
@@ -49,4 +64,8 @@ def get_cpu_model_choices() -> dict[str, str]:
                 # Skip files that can't be parsed or are not there
                 continue
 
-    return models
+        if models:
+            for truenas_arch in truenas_archs:
+                result[truenas_arch] = models
+
+    return result

--- a/truenas_pylibvirt/utils/ovmf.py
+++ b/truenas_pylibvirt/utils/ovmf.py
@@ -4,31 +4,44 @@ import re
 
 
 OVMF_DIR = '/usr/share/OVMF'
+AAVMF_DIR = '/usr/share/AAVMF'
 
 
 @functools.cache
 def get_ovmf_vars_file(code_filename: str, ovmf_dir: str = OVMF_DIR) -> str | None:
     """
-    Given an OVMF CODE filename, return the matching VARS file path.
+    Given an OVMF or AAVMF CODE filename, return the matching VARS file path.
 
-    Matching is done based on:
-    - Size variant (e.g., _4M must match)
+    Prefix selects the firmware family:
+    - OVMF_CODE*  -> ovmf_dir + OVMF_VARS  (x86)
+    - AAVMF_CODE* -> AAVMF_DIR + AAVMF_VARS (aarch64)
+
+    Matching also handles:
+    - Size variant (e.g., _4M must match -- AAVMF has no size variants)
     - Secure boot support (secboot/ms CODE files get .ms VARS)
     - Special variants like snakeoil get their matching VARS
 
     Args:
-        code_filename: The OVMF CODE filename (e.g., 'OVMF_CODE.secboot.fd')
-        ovmf_dir: Directory containing OVMF files (default: /usr/share/OVMF)
+        code_filename: The CODE filename (e.g., 'OVMF_CODE.secboot.fd' or
+                       'AAVMF_CODE.ms.fd')
+        ovmf_dir: Directory containing OVMF files (default: /usr/share/OVMF).
+                  Ignored for AAVMF inputs which always use AAVMF_DIR.
 
     Returns:
         Full path to matching VARS file, or None if no match found
     """
     basename = os.path.basename(code_filename)
 
-    if not basename.startswith('OVMF_CODE'):
+    if basename.startswith('OVMF_CODE'):
+        vars_prefix = 'OVMF_VARS'
+        vars_dir = ovmf_dir
+    elif basename.startswith('AAVMF_CODE'):
+        vars_prefix = 'AAVMF_VARS'
+        vars_dir = AAVMF_DIR
+    else:
         return None
 
-    # Extract size variant (e.g., '_4M')
+    # Extract size variant (e.g., '_4M' for OVMF; AAVMF has none)
     size_match = re.search(r'(_\d+M)', basename)
     size_variant = size_match.group(1) if size_match else ''
 
@@ -42,17 +55,17 @@ def get_ovmf_vars_file(code_filename: str, ovmf_dir: str = OVMF_DIR) -> str | No
     candidates = []
 
     if is_snakeoil:
-        candidates.append(f'OVMF_VARS{size_variant}.snakeoil.fd')
-        candidates.append(f'OVMF_VARS{size_variant}.ms.fd')
+        candidates.append(f'{vars_prefix}{size_variant}.snakeoil.fd')
+        candidates.append(f'{vars_prefix}{size_variant}.ms.fd')
     elif is_secboot:
-        candidates.append(f'OVMF_VARS{size_variant}.ms.fd')
+        candidates.append(f'{vars_prefix}{size_variant}.ms.fd')
 
     # Always add the basic variant as fallback
-    candidates.append(f'OVMF_VARS{size_variant}.fd')
+    candidates.append(f'{vars_prefix}{size_variant}.fd')
 
     # Find first existing candidate
     for candidate in candidates:
-        candidate_path = os.path.join(ovmf_dir, candidate)
+        candidate_path = os.path.join(vars_dir, candidate)
         if os.path.exists(candidate_path):
             return candidate_path
 


### PR DESCRIPTION
Enable aarch64 guest VMs across the XML generator, with cross-architecture emulation (TCG) when host arch differs from guest arch. Same-arch guests keep KVM.

- `_type()`: emit `<domain type='kvm'>` only when guest arch matches host and `/dev/kvm` exists; otherwise emit `qemu`. Special-case i686-on-x86_64 since KVM-x86 accelerates 32-bit guests on 64-bit hosts.

- `_os_xml()`: route the `<loader>` path to `/usr/share/AAVMF` when the bootloader filename starts with `AAVMF_CODE`, otherwise `/usr/share/OVMF`.

- `_features_xml_children()`: aarch64 guests emit only `<acpi/>`. The x86 elements (`<apic>`, `<msrs>`, `<kvm><hidden>`, `<hyperv>`, `<smm>`) stay reserved to non-aarch64 paths since libvirt rejects them on the virt machine.

- TPM model: `tpm-tis` (the libvirt-schema name; libvirt emits qemu's `tpm-tis-device` for the aarch64 virt machine) on aarch64, otherwise `tpm-crb`. `tpm-tis-device` is the qemu device name and is not accepted by libvirt's domain schema.

`get_cpu_model_choices()` now returns `dict[arch_type, dict[model, model]]` instead of the prior flat `dict[model, model]`. Keys are TrueNAS arch_type values (`x86_64`, `i686`, `aarch64`, `ppc64`); translation from libvirt's cpu_map names (`x86`/`arm`/`ppc64`) happens via `_ARCH_MAP` inside this module, so callers don't translate.

aarch64 CPU models (Ampere-1/1a, Neoverse-N1/N2/V1, Kunpeng-920, ThunderX2-99xx, a64fx, cortex-a53/a57/a72, FT-2000+, Falkor, Tengyun-S2500) are now surfaced. Previously excluded by a `virsh cpu-models arm fails` comment that no longer applies — this code path parses the cpu_map XML directly and does not call virsh; arm cpu_map files parse fine.

Callers gain per-arch validation as a side effect: an x86_64 guest can no longer validate-pass with a ppc64 model name and then fail at libvirt domain-define time.

`get_ovmf_vars_file()` generalized to handle both `OVMF_CODE*` and `AAVMF_CODE*` inputs. New `AAVMF_DIR = '/usr/share/AAVMF'` constant. Prefix detection branches the firmware directory and the VARS-filename prefix; existing matching logic for size variants, secboot, and snakeoil applies to both. The `ovmf_dir` parameter is kept for backward compatibility (the existing OVMF-with-custom-dir test still passes) but is ignored for AAVMF inputs, which always resolve under `AAVMF_DIR`.

New `tests/domain/test_vm_xml.py`: 28 cases covering `_type()` across host/guest/KVM combinations, `_features_xml_children` arch gating with all combinations of x86 feature flags, and TPM model selection. `tests/utils/test_ovmf.py` extended with 8 AAVMF parametrize cases, including the `AAVMF_CODE.no-secboot.fd` edge case (must not trip secboot detection via substring match on the bare token).

----
**NOTE**: Because of the `get_cpu_model_choices` API change, **this PR must be merged at the same time as the corresponding `middleware` one** (#[19167](https://github.com/truenas/middleware/pull/19167)).  (This also accounts for the `mypy` breakage below.)

FWIW manual tests with a build with both (`middleware `& `truenas_pylibvirt`) changes passed:
```
vm/test_vm.py::test_vm[amd64] PASSED
vm/test_vm.py::test_vm[arm64] PASSED
```