### PR TITLE
NAS-141495 / 27.0.0-BETA.1 / Skip cpu_map architectures without a name attribute

### DIFF
--- a/truenas_pylibvirt/utils/cpu.py
+++ b/truenas_pylibvirt/utils/cpu.py
@@ -35,6 +35,9 @@ def get_cpu_model_choices() -> dict[str, dict[str, str]]:
     # Process architectures whose cpu_map XML files we parse
     for arch in index_xml.findall('.//arch[@name]'):
         arch_name = arch.get('name')
+        if arch_name is None:
+            continue
+
         truenas_archs = _ARCH_MAP.get(arch_name)
         if truenas_archs is None:
             continue


### PR DESCRIPTION
## Problem
`get_cpu_model_choices()` passes `arch.get('name')` straight into `_ARCH_MAP.get(...)`. `Element.get()` is typed `str | None`, so under `mypy --strict` using it as a `dict[str, ...]` key is an `arg-type` error, which fails the build action. This came in with the cpu_map arch refactor.

## Solution
Skip any `arch` element whose `name` attribute is missing before the lookup, which narrows the value to `str`. This is a no-op at runtime since the `.//arch[@name]` query already only returns elements that have a name.

Regression from https://github.com/truenas/truenas_pylibvirt/pull/56