### PR TITLE
NAS-1413150 / 26.0.0-RC.1 / Reject non-colon NIC MAC addresses

### DIFF
--- a/tests/device/test_nic.py
+++ b/tests/device/test_nic.py
@@ -91,6 +91,11 @@ def test_nic_identity(mock_device_delegate):
 @pytest.mark.parametrize("mac,expected_error", [
     ("00:a0:99:7e:bb:8a", None),  # Valid MAC
     ("ff:a0:99:7e:bb:8a", "MAC address must not start with"),  # Invalid - starts with ff
+    ("10-66-6a-1f-f1-b1", "MAC address must be a colon-separated"),  # Invalid - dash separators
+    ("10-66-6A-1F-F1-B1", "MAC address must be a colon-separated"),  # Invalid - dash separators, uppercase
+    ("00a0997ebb8a", "MAC address must be a colon-separated"),  # Invalid - no separators
+    ("00:a0:99:7e:bb", "MAC address must be a colon-separated"),  # Invalid - too short
+    ("gg:gg:gg:gg:gg:gg", "MAC address must be a colon-separated"),  # Invalid - non-hex digits
 ])
 def test_nic_mac_validation(mac, expected_error, mock_device_delegate):
     """Test NIC MAC address validation."""

--- a/truenas_pylibvirt/device/nic.py
+++ b/truenas_pylibvirt/device/nic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator
@@ -18,6 +19,10 @@ from .base import Device, DeviceXmlContext
 
 if TYPE_CHECKING:
     from ..libvirtd.connection import Connection
+
+
+# libvirt's defineXML only parses colon-separated MAC addresses.
+MAC_ADDRESS_RE = re.compile(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$')
 
 
 class NICDeviceType(enum.Enum):
@@ -114,8 +119,13 @@ class NICDevice(Device):
                 ('trust_guest_rx_filters', 'This can only be set when "type" of NIC device is "VIRTIO"')
             )
 
-        if self.mac and self.mac.lower().startswith('ff'):
-            verrors.append(
-                ('mac', 'MAC address must not start with `ff`')
-            )
+        if self.mac:
+            if not MAC_ADDRESS_RE.match(self.mac):
+                verrors.append(
+                    ('mac', 'MAC address must be a colon-separated hexadecimal value (e.g. `00:a0:99:7e:bb:8a`)')
+                )
+            elif self.mac.lower().startswith('ff'):
+                verrors.append(
+                    ('mac', 'MAC address must not start with `ff`')
+                )
         return verrors


### PR DESCRIPTION
## Problem
A custom NIC MAC entered with dash, no-separator, or mixed separators (e.g. `10-66-6A-1F-F1-B1`) was only checked for the `ff` prefix, so it reached libvirt's `defineXML`, which parses colon-separated MACs only and failed the start with `XML error: unable to parse mac address`.

## Solution
Validate `mac` against a colon-separated pattern in `NICDevice.validate_impl()` so the bad value is rejected at device validation time with a clear message instead of blowing up at start. The `ff`-prefix check is kept for valid colon MACs.

Backport of https://github.com/truenas/truenas_pylibvirt/pull/55