### PR TITLE
NAS-141503 / 27.0.0-BETA.1 / Add is_no_domain_error helper for libvirt error classification

### DIFF
--- a/tests/test_is_no_domain_error.py
+++ b/tests/test_is_no_domain_error.py
@@ -1,0 +1,21 @@
+import libvirt
+
+from truenas_pylibvirt import is_no_domain_error
+
+
+def _libvirt_error(code):
+    e = libvirt.libvirtError("error")
+    e.err = (code, None, "message", None, None, None, None, -1, -1)
+    return e
+
+
+def test_true_for_no_domain():
+    assert is_no_domain_error(_libvirt_error(libvirt.VIR_ERR_NO_DOMAIN)) is True
+
+
+def test_false_for_other_libvirt_error():
+    assert is_no_domain_error(_libvirt_error(libvirt.VIR_ERR_INTERNAL_ERROR)) is False
+
+
+def test_false_for_non_libvirt_exception():
+    assert is_no_domain_error(ValueError("nope")) is False

--- a/truenas_pylibvirt/__init__.py
+++ b/truenas_pylibvirt/__init__.py
@@ -12,7 +12,7 @@ from .domain.vm.configuration import (  # noqa
     VmBootloader, VmCpuMode, VmDomainConfiguration,
 )
 from .domain.vm.domain import VmDomain  # noqa
-from .error import Error, DomainDoesNotExistError  # noqa
+from .error import Error, DomainDoesNotExistError, is_no_domain_error  # noqa
 from .libvirtd.connection import Connection  # noqa
 from .libvirtd.connection_manager import ConnectionManager  # noqa
 from .libvirtd.service_delegate import ServiceDelegate  # noqa
@@ -32,6 +32,7 @@ __all__ = [
     'DomainDoesNotExistError',
     'DomainManagers',
     'Error',
+    'is_no_domain_error',
     'NICDevice',
     'NICDeviceModel',
     'NICDeviceType',

--- a/truenas_pylibvirt/error.py
+++ b/truenas_pylibvirt/error.py
@@ -1,4 +1,6 @@
-__all__ = ["Error", "DomainDoesNotExistError"]
+import libvirt
+
+__all__ = ["Error", "DomainDoesNotExistError", "is_no_domain_error"]
 
 
 class Error(Exception):
@@ -7,3 +9,10 @@ class Error(Exception):
 
 class DomainDoesNotExistError(Error):
     pass
+
+
+def is_no_domain_error(exc: BaseException) -> bool:
+    return (
+        isinstance(exc, libvirt.libvirtError)
+        and exc.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN
+    )

--- a/truenas_pylibvirt/libvirtd/connection.py
+++ b/truenas_pylibvirt/libvirtd/connection.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, TYPE_CHECKING
 
 import libvirt
 
-from ..error import Error
+from ..error import Error, is_no_domain_error
 
 if TYPE_CHECKING:
     from .connection_manager import ConnectionManager
@@ -98,7 +98,7 @@ class Connection:
         try:
             return self.connection.lookupByName(uuid)
         except libvirt.libvirtError as e:
-            if e.err[0] == libvirt.VIR_ERR_NO_DOMAIN:
+            if is_no_domain_error(e):
                 return None
 
             raise


### PR DESCRIPTION
## Context
Both this library and the middleware need to distinguish libvirt's "domain not found" (`VIR_ERR_NO_DOMAIN`) from other libvirt errors. The check was previously inlined in `Connection.get_domain`, and middleware's per-domain state-gathering loop now needs the same classification.

## Solution
Added `is_no_domain_error()` to `error.py` (exported from the package) and refactored `get_domain` to use it, so the classification has a single source of truth.