### PR TITLE
NAS-141512 / 27.0.0-BETA.1 / Share one USB controller across devices of the same type

### DIFF
--- a/tests/device/test_usb.py
+++ b/tests/device/test_usb.py
@@ -145,6 +145,256 @@ def test_usb_validation_missing_device_and_ids(mock_device_delegate):
     assert any("must be specified" in error[1] for error in errors)
 
 
+def _capability(vendor_id, product_id, bus='001', device='002'):
+    return {
+        'capability': {
+            'vendor_id': vendor_id,
+            'product_id': product_id,
+            'bus': bus,
+            'device': device,
+        },
+        'available': True,
+    }
+
+
+def _hostdev_bus(hostdev):
+    address = hostdev.find("address[@type='usb']")
+    return address.get('bus') if address is not None else None
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_ids')
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_two_devices_same_type_single_controller(
+    mock_find_by_name, mock_find_by_ids, device_context, mock_device_delegate
+):
+    """Two distinct devices sharing a controller type emit exactly one controller, shared by both."""
+    mock_find_by_ids.side_effect = lambda v, p: {
+        ('0x80ee', '0x0021'): 'usb_1_2',
+        ('0x0718', '0x7722'): 'usb_3_4',
+    }.get((v, p))
+    mock_find_by_name.side_effect = lambda n: {
+        'usb_1_2': _capability('0x80ee', '0x0021'),
+        'usb_3_4': _capability('0x0718', '0x7722'),
+    }.get(n)
+
+    first = USBDevice(
+        vendor_id='0x80ee', product_id='0x0021', device=None,
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+    second = USBDevice(
+        vendor_id='0x0718', product_id='0x7722', device=None,
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+
+    first_elements = first.xml(device_context)
+    second_elements = second.xml(device_context)
+
+    controllers = [e for e in first_elements + second_elements if e.tag == 'controller']
+    hostdevs = [e for e in first_elements + second_elements if e.tag == 'hostdev']
+    assert len(controllers) == 1
+    assert len(hostdevs) == 2
+    # The second device of the same type must not re-emit the controller.
+    assert [e for e in second_elements if e.tag == 'controller'] == []
+
+    index = controllers[0].get('index')
+    assert all(_hostdev_bus(hostdev) == index for hostdev in hostdevs)
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_ids')
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_two_devices_different_types_two_controllers(
+    mock_find_by_name, mock_find_by_ids, device_context, mock_device_delegate
+):
+    """Two devices with different non-default controller types each get their own controller."""
+    mock_find_by_ids.side_effect = lambda v, p: {
+        ('0x80ee', '0x0021'): 'usb_1_2',
+        ('0x0718', '0x7722'): 'usb_3_4',
+    }.get((v, p))
+    mock_find_by_name.side_effect = lambda n: {
+        'usb_1_2': _capability('0x80ee', '0x0021'),
+        'usb_3_4': _capability('0x0718', '0x7722'),
+    }.get(n)
+
+    first = USBDevice(
+        vendor_id='0x80ee', product_id='0x0021', device=None,
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+    second = USBDevice(
+        vendor_id='0x0718', product_id='0x7722', device=None,
+        controller_type='ehci', device_delegate=mock_device_delegate,
+    )
+
+    first_elements = first.xml(device_context)
+    second_elements = second.xml(device_context)
+
+    controllers = [e for e in first_elements + second_elements if e.tag == 'controller']
+    assert len(controllers) == 2
+    assert len({c.get('index') for c in controllers}) == 2
+
+    first_controller = next(e for e in first_elements if e.tag == 'controller')
+    second_controller = next(e for e in second_elements if e.tag == 'controller')
+    first_hostdev = next(e for e in first_elements if e.tag == 'hostdev')
+    second_hostdev = next(e for e in second_elements if e.tag == 'hostdev')
+    assert _hostdev_bus(first_hostdev) == first_controller.get('index')
+    assert _hostdev_bus(second_hostdev) == second_controller.get('index')
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_nec_xhci_no_controller_bus_zero(mock_find_usb, device_context, mock_device_delegate):
+    """nec-xhci is libvirt's implicit controller (index 0) and never emits an explicit element."""
+    mock_find_usb.side_effect = lambda n: {
+        'usb_1_2': _capability('0x80ee', '0x0021'),
+        'usb_3_4': _capability('0x0718', '0x7722'),
+    }.get(n)
+
+    first = USBDevice(
+        vendor_id=None, product_id=None, device='usb_1_2',
+        controller_type='nec-xhci', device_delegate=mock_device_delegate,
+    )
+    second = USBDevice(
+        vendor_id=None, product_id=None, device='usb_3_4',
+        controller_type='nec-xhci', device_delegate=mock_device_delegate,
+    )
+
+    elements = first.xml(device_context) + second.xml(device_context)
+    assert [e for e in elements if e.tag == 'controller'] == []
+    hostdevs = [e for e in elements if e.tag == 'hostdev']
+    assert len(hostdevs) == 2
+    assert all(_hostdev_bus(hostdev) == '0' for hostdev in hostdevs)
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_controller_type_none_no_controller_no_address(
+    mock_find_usb, device_context, mock_device_delegate
+):
+    """A device without a controller type (e.g. containers) emits no controller and no address."""
+    mock_find_usb.return_value = _capability('0x80ee', '0x0021')
+
+    device = USBDevice(
+        vendor_id=None, product_id=None, device='usb_1_2',
+        controller_type=None, device_delegate=mock_device_delegate,
+    )
+
+    elements = device.xml(device_context)
+    assert [e for e in elements if e.tag == 'controller'] == []
+    hostdev = next(e for e in elements if e.tag == 'hostdev')
+    assert hostdev.find("address[@type='usb']") is None
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_mixed_nec_and_qemu_xhci_indices(mock_find_usb, device_context, mock_device_delegate):
+    """nec-xhci and qemu-xhci devices coexist without duplicate or colliding indices."""
+    mock_find_usb.side_effect = lambda n: {
+        'usb_1_2': _capability('0x80ee', '0x0021'),
+        'usb_3_4': _capability('0x0718', '0x7722'),
+    }.get(n)
+
+    nec = USBDevice(
+        vendor_id=None, product_id=None, device='usb_1_2',
+        controller_type='nec-xhci', device_delegate=mock_device_delegate,
+    )
+    qemu = USBDevice(
+        vendor_id=None, product_id=None, device='usb_3_4',
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+
+    nec_elements = nec.xml(device_context)
+    qemu_elements = qemu.xml(device_context)
+
+    assert [e for e in nec_elements if e.tag == 'controller'] == []
+    nec_hostdev = next(e for e in nec_elements if e.tag == 'hostdev')
+    assert _hostdev_bus(nec_hostdev) == '0'
+
+    qemu_controllers = [e for e in qemu_elements if e.tag == 'controller']
+    assert len(qemu_controllers) == 1
+    qemu_hostdev = next(e for e in qemu_elements if e.tag == 'hostdev')
+    assert _hostdev_bus(qemu_hostdev) == qemu_controllers[0].get('index')
+    assert qemu_controllers[0].get('index') != '0'
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_port_attribute_omitted(mock_find_usb, device_context, mock_device_delegate):
+    """The device address omits the port so libvirt auto-assigns a free port on the shared bus."""
+    mock_find_usb.return_value = _capability('0x80ee', '0x0021')
+
+    device = USBDevice(
+        vendor_id=None, product_id=None, device='usb_1_2',
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+
+    hostdev = next(e for e in device.xml(device_context) if e.tag == 'hostdev')
+    address = hostdev.find("address[@type='usb']")
+    assert address is not None
+    assert address.get('port') is None
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_unavailable_device_does_not_consume_controller_index(
+    mock_find_usb, device_context, mock_device_delegate
+):
+    """A device whose lookup fails returns nothing before touching the counters, so a later
+    device of the same type still gets the first controller index."""
+    mock_find_usb.side_effect = lambda n: {
+        'usb_3_4': _capability('0x0718', '0x7722'),
+    }.get(n)
+
+    phantom = USBDevice(
+        vendor_id=None, product_id=None, device='usb_missing',
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+    real = USBDevice(
+        vendor_id=None, product_id=None, device='usb_3_4',
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+
+    assert phantom.xml(device_context) == []
+
+    real_elements = real.xml(device_context)
+    controllers = [e for e in real_elements if e.tag == 'controller']
+    assert len(controllers) == 1
+    real_hostdev = next(e for e in real_elements if e.tag == 'hostdev')
+    assert _hostdev_bus(real_hostdev) == controllers[0].get('index')
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_interleaved_types_reuse_existing_controller(
+    mock_find_usb, device_context, mock_device_delegate
+):
+    """A type seen again after an intervening different type reuses its controller index and
+    emits no second controller."""
+    mock_find_usb.side_effect = lambda n: {
+        'usb_1_2': _capability('0x80ee', '0x0021'),
+        'usb_3_4': _capability('0x0718', '0x7722'),
+        'usb_5_6': _capability('0x1d6b', '0x0003'),
+    }.get(n)
+
+    first_ehci = USBDevice(
+        vendor_id=None, product_id=None, device='usb_1_2',
+        controller_type='ehci', device_delegate=mock_device_delegate,
+    )
+    qemu = USBDevice(
+        vendor_id=None, product_id=None, device='usb_3_4',
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+    second_ehci = USBDevice(
+        vendor_id=None, product_id=None, device='usb_5_6',
+        controller_type='ehci', device_delegate=mock_device_delegate,
+    )
+
+    first_elements = first_ehci.xml(device_context)
+    qemu_elements = qemu.xml(device_context)
+    second_elements = second_ehci.xml(device_context)
+
+    first_controller = next(e for e in first_elements if e.tag == 'controller')
+    qemu_controller = next(e for e in qemu_elements if e.tag == 'controller')
+    assert first_controller.get('index') != qemu_controller.get('index')
+
+    # The second ehci shares the first ehci's controller, so it emits no controller of its own.
+    assert [e for e in second_elements if e.tag == 'controller'] == []
+    second_hostdev = next(e for e in second_elements if e.tag == 'hostdev')
+    assert _hostdev_bus(second_hostdev) == first_controller.get('index')
+
+
 def test_usb_conflict_detection(mock_device_delegate):
     """Test USB device conflict detection."""
     device = USBDevice(

--- a/truenas_pylibvirt/device/counters.py
+++ b/truenas_pylibvirt/device/counters.py
@@ -9,9 +9,11 @@ class Counters:
         self._boot_no = count(1)
         self._scsi_device_no = count(1)
         self._usb_controller_no = count(1)
-        # nec-xhci is added by default for each domain by libvirt so we update our mapping accordingly
+        # The display device emits the nec-xhci controller and libvirt assigns it index 0, so we
+        # seed our mapping accordingly and never emit a nec-xhci controller from a USB device.
         self._usb_controllers_no = defaultdict(lambda: next(self._usb_controller_no))
         self._usb_controllers_no["nec-xhci"] = 0
+        self._emitted_usb_controllers: set[str] = set()
         self._virtual_device_no = count(1)
 
     def next_boot_no(self) -> int:
@@ -22,6 +24,15 @@ class Counters:
 
     def usb_controller_no(self, type_: str) -> int:
         return self._usb_controllers_no[type_]
+
+    def should_emit_usb_controller(self, type_: str) -> bool:
+        # A single USB controller hosts many devices, so its <controller> element must be
+        # emitted only once per type. Returns True the first time a type is seen and False
+        # afterwards, letting subsequent devices of the same type share the controller.
+        if type_ in self._emitted_usb_controllers:
+            return False
+        self._emitted_usb_controllers.add(type_)
+        return True
 
     def next_virtual_device_no(self) -> int:
         return next(self._virtual_device_no)

--- a/truenas_pylibvirt/device/usb.py
+++ b/truenas_pylibvirt/device/usb.py
@@ -39,15 +39,39 @@ class USBDevice(Device):
                 ],
             ),
         ]
+        bus_no = None
         if self.controller_type:
+            bus_no = context.counters.usb_controller_no(self.controller_type)
             children.append(
                 xml_element(
                     "address",
                     attributes={
                         "type": "usb",
-                        "bus": str(context.counters.usb_controller_no(self.controller_type)),
+                        "bus": str(bus_no),
                     },
                 ),
+            )
+
+        controllers = []
+        # The nec-xhci controller at index 0 is supplied by the display device (or, lacking one,
+        # auto-added by libvirt), so a USB device never emits it itself. For other types the
+        # controller is emitted once and shared by every device of that type; emitting it per
+        # device produces duplicate controllers that libvirt rejects with "Duplicate USB
+        # controllers with index N".
+        if (
+            self.controller_type
+            and self.controller_type != 'nec-xhci'
+            and context.counters.should_emit_usb_controller(self.controller_type)
+        ):
+            controllers.append(
+                xml_element(
+                    "controller",
+                    attributes={
+                        "type": "usb",
+                        "index": str(bus_no),
+                        "model": self.controller_type,
+                    },
+                )
             )
 
         return [
@@ -60,18 +84,7 @@ class USBDevice(Device):
                 },
                 children=children,
             ),
-            *(
-                [
-                    xml_element(
-                        "controller",
-                        attributes={
-                            "type": "usb",
-                            "index": str(context.counters.usb_controller_no(self.controller_type)),
-                            "model": self.controller_type
-                        }
-                    )
-                ] if self.controller_type and self.controller_type != 'nec-xhci' else []
-            )
+            *controllers,
         ]
 
     def identity_impl(self) -> str:


### PR DESCRIPTION
## Problem
Starting a VM with two or more USB devices that share the same non-default controller type failed with "XML error: Duplicate USB controllers with index N". USBDevice.xml() emitted a <controller> element for every device, and the controller index is keyed by controller type, so two devices of the same type produced two controllers with the same index, which libvirt rejects.

## Solution
Track which controller types have already emitted a <controller> within a domain (in the per-domain Counters) and emit it only once per type; subsequent devices of that type attach to the shared controller via the same address bus, with the port left for libvirt to auto-assign. This matches the supported libvirt/QEMU topology of one controller hosting many devices. nec-xhci stays exempt as libvirt's implicit default. Added regression tests for same-type sharing, distinct types, nec-xhci, a missing controller type, mixed types, and port omission.