### PR TITLE
NAS-141549 / 27.0.0-BETA.1 / Add guest_agent_command to Connection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,5 @@ addopts = "-v --tb=short"
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["libvirt.*", "libvirt_lxc.*", "pyudev.*"]
+module = ["libvirt.*", "libvirt_lxc.*", "libvirt_qemu", "pyudev.*"]
 ignore_missing_imports = true

--- a/truenas_pylibvirt/libvirtd/connection.py
+++ b/truenas_pylibvirt/libvirtd/connection.py
@@ -8,6 +8,7 @@ import os
 from typing import Any, Callable, TYPE_CHECKING
 
 import libvirt
+import libvirt_qemu
 
 from ..error import Error, is_no_domain_error
 
@@ -105,6 +106,13 @@ class Connection:
 
     def domain_memory_usage(self, domain: Any) -> int:
         return int(domain.memoryStats().get("actual", 0) * 1024)
+
+    def guest_agent_command(self, domain: Any, command: str, timeout: int = 30) -> str:
+        """Send a QEMU guest agent command and return the raw JSON response string.
+
+        Raises libvirt.libvirtError if the guest agent is unavailable or times out.
+        """
+        return str(libvirt_qemu.qemuAgentCommand(domain, command, timeout, 0))
 
     def domain_state(self, domain: Any) -> DomainState:
         return {


### PR DESCRIPTION
Wraps `libvirt_qemu.qemuAgentCommand` so callers do not need to import `libvirt_qemu` directly.