### PR TITLE
NAS-141623 / 27.0.0-BETA.1 / Add PciAddress support for NIC devices

### DIFF
--- a/truenas_pylibvirt/__init__.py
+++ b/truenas_pylibvirt/__init__.py
@@ -1,5 +1,5 @@
 from .device.storage import DiskStorageDevice, StorageDeviceType, StorageDeviceIoType  # noqa
-from .device.nic import NICDevice, NICDeviceModel, NICDeviceType  # noqa
+from .device.nic import NICDevice, NICDeviceModel, NICDeviceType, PciAddress  # noqa
 from .domain.base.configuration import Time  # noqa
 from .domain.base.domain import BaseDomain  # noqa
 from .domain.container.configuration import (  # noqa
@@ -37,6 +37,7 @@ __all__ = [
     'NICDevice',
     'NICDeviceModel',
     'NICDeviceType',
+    'PciAddress',
     'ServiceDelegate',
     'StorageDeviceIoType',
     'StorageDeviceType',

--- a/truenas_pylibvirt/device/__init__.py
+++ b/truenas_pylibvirt/device/__init__.py
@@ -5,7 +5,7 @@ from .delegate import DeviceDelegate  # noqa
 from .display import DisplayDevice, DisplayDeviceType  # noqa
 from .filesystem import FilesystemDevice # noqa
 from .gpu import GPUDevice  # noqa
-from .nic import NICDevice, NICDeviceType, NICDeviceModel  # noqa
+from .nic import NICDevice, NICDeviceType, NICDeviceModel, PciAddress  # noqa
 from .pci import PCIDevice  # noqa
 from .storage import DiskStorageDevice, RawStorageDevice, StorageDeviceType, StorageDeviceIoType  # noqa
 from .usb import USBDevice  # noqa
@@ -22,6 +22,7 @@ __all__ = [
     'NICDevice',
     'NICDeviceModel',
     'NICDeviceType',
+    'PciAddress',
     'PCIDevice',
     'RawStorageDevice',
     'StorageDeviceIoType',

--- a/truenas_pylibvirt/device/nic.py
+++ b/truenas_pylibvirt/device/nic.py
@@ -35,6 +35,24 @@ class NICDeviceModel(enum.Enum):
     VIRTIO = "VIRTIO"
 
 
+@dataclass
+class PciAddress:
+    bus: int
+    slot: int
+    function: int = 0
+    domain: int = 0
+
+    def to_xml_element(self) -> ElementTree.Element:
+        from ..xml import xml_element
+        return xml_element("address", attributes={
+            "type": "pci",
+            "domain": f"0x{self.domain:04x}",
+            "bus": f"0x{self.bus:02x}",
+            "slot": f"0x{self.slot:02x}",
+            "function": f"0x{self.function:x}",
+        })
+
+
 @dataclass(kw_only=True)
 class NICDevice(Device):
 
@@ -43,6 +61,7 @@ class NICDevice(Device):
     model: NICDeviceModel | None
     mac: str | None
     trust_guest_rx_filters: bool
+    pci_address: PciAddress | None = None
 
     def xml(self, context: DeviceXmlContext) -> list[ElementTree.Element]:
         children = []
@@ -50,6 +69,8 @@ class NICDevice(Device):
             children.append(xml_element("model", attributes={"type": self.model.value.lower()}))
         if self.mac:
             children.append(xml_element("mac", attributes={"address": self.mac}))
+        if self.pci_address:
+            children.append(self.pci_address.to_xml_element())
 
         match self.type_:
             case NICDeviceType.BRIDGE:

--- a/truenas_pylibvirt/device/nic.py
+++ b/truenas_pylibvirt/device/nic.py
@@ -42,15 +42,6 @@ class PciAddress:
     function: int = 0
     domain: int = 0
 
-    def to_xml_element(self) -> ElementTree.Element:
-        return xml_element("address", attributes={
-            "type": "pci",
-            "domain": f"0x{self.domain:04x}",
-            "bus": f"0x{self.bus:02x}",
-            "slot": f"0x{self.slot:02x}",
-            "function": f"0x{self.function:x}",
-        })
-
 
 @dataclass(kw_only=True)
 class NICDevice(Device):
@@ -69,7 +60,13 @@ class NICDevice(Device):
         if self.mac:
             children.append(xml_element("mac", attributes={"address": self.mac}))
         if self.pci_address:
-            children.append(self.pci_address.to_xml_element())
+            children.append(xml_element("address", attributes={
+                "type": "pci",
+                "domain": f"0x{self.pci_address.domain:04x}",
+                "bus": f"0x{self.pci_address.bus:02x}",
+                "slot": f"0x{self.pci_address.slot:02x}",
+                "function": f"0x{self.pci_address.function:x}",
+            }))
 
         match self.type_:
             case NICDeviceType.BRIDGE:

--- a/truenas_pylibvirt/device/nic.py
+++ b/truenas_pylibvirt/device/nic.py
@@ -43,7 +43,6 @@ class PciAddress:
     domain: int = 0
 
     def to_xml_element(self) -> ElementTree.Element:
-        from ..xml import xml_element
         return xml_element("address", attributes={
             "type": "pci",
             "domain": f"0x{self.domain:04x}",

--- a/truenas_pylibvirt/domain/vm/xml.py
+++ b/truenas_pylibvirt/domain/vm/xml.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
 from ...device.display import DisplayDevice, DisplayDeviceType
+from ...device.nic import NICDevice
 from ...utils import kvm_supported
 from ...xml import xml_element
 from ..base.xml import BaseDomainXmlGenerator
@@ -169,8 +170,45 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
 
         return []
 
+    def _pci_expansion_controllers(self) -> list[ElementTree.Element]:
+        """Inject PCI expansion controllers for any NIC pinned to a non-zero PCI bus.
+
+        q35 machines (pcie-root) use pcie-root-port; i440fx machines (pci-root)
+        use pci-bridge. Machine type is detected from the configuration; an absent
+        or unrecognised machine_type is treated as i440fx (QEMU's default).
+        """
+        needed_buses: set[int] = set()
+        for device in self.domain.configuration.devices:
+            if isinstance(device, NICDevice) and device.pci_address and device.pci_address.bus > 0:
+                needed_buses.add(device.pci_address.bus)
+
+        if not needed_buses:
+            return []
+
+        is_q35 = 'q35' in (self.domain.configuration.machine_type or '')
+
+        controllers = []
+        for bus in sorted(needed_buses):
+            if is_q35:
+                controllers.append(xml_element(
+                    "controller",
+                    attributes={"type": "pci", "model": "pcie-root-port", "index": str(bus)},
+                    children=[
+                        xml_element("target", attributes={"chassis": str(bus), "port": f"0x{0x10 + bus - 1:x}"}),
+                    ],
+                ))
+            else:
+                controllers.append(xml_element(
+                    "controller",
+                    attributes={"type": "pci", "model": "pci-bridge", "index": str(bus)},
+                    children=[
+                        xml_element("target", attributes={"chassisNr": str(bus)}),
+                    ],
+                ))
+        return controllers
+
     def _devices_xml_children(self) -> list[ElementTree.Element]:
-        children = super()._devices_xml_children()
+        children = list(self._pci_expansion_controllers()) + list(super()._devices_xml_children())
 
         display_device_available = False
         spice_server_available = False


### PR DESCRIPTION
Allows a NIC to be pinned to a specific guest PCI address (bus/slot/function), enabling predictable interface naming (e.g. enp1s0).

q35 machines inject a pcie-root-port controller for any non-zero bus; i440fx machines inject a pci-bridge.