### PR TITLE
NAS-141710 / 27.0.0-BETA.1 / Add ISCSIDiskDevice to VMs

### DIFF
--- a/tests/device/test_iscsi_disk.py
+++ b/tests/device/test_iscsi_disk.py
@@ -1,0 +1,213 @@
+"""Tests for ISCSIDiskDevice and ISCSIDiskTarget."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import Mock
+
+from truenas_pylibvirt.device import ISCSIDiskDevice, ISCSIDiskTarget
+from truenas_pylibvirt.device.base import QemuArgsContext
+from truenas_pylibvirt.device.delegate import DeviceDelegate
+
+
+VALID_IQN_TARGET = "iqn.2026-06.net.ixsystems.tnguest:ha000-d000"
+VALID_IQN_INITIATOR = "iqn.2026-06.net.ixsystems.tnguest:ha000"
+PORTAL_V4 = "10.99.0.100"
+PORTAL_V6 = "2001:db8::1"
+
+CTX_Q35 = QemuArgsContext(machine_type="pc-q35-10.0")
+CTX_VIRT = QemuArgsContext(machine_type="virt-9.2")
+CTX_I440FX = QemuArgsContext(machine_type="pc-i440fx-9.2")
+CTX_UNKNOWN = QemuArgsContext(machine_type=None)
+
+
+def _device(
+    portal_address=PORTAL_V4,
+    targets=None,
+    initiator_iqn=VALID_IQN_INITIATOR,
+    controller_slot=0x15,
+    delegate=None,
+):
+    if targets is None:
+        targets = [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)]
+    if delegate is None:
+        d = Mock(spec=DeviceDelegate)
+        d.is_available = Mock(return_value=True)
+        delegate = d
+    return ISCSIDiskDevice(
+        portal_address=portal_address,
+        targets=targets,
+        initiator_iqn=initiator_iqn,
+        controller_slot=controller_slot,
+        device_delegate=delegate,
+    )
+
+
+def test_xml_returns_empty(device_context, mock_device_delegate):
+    """ISCSIDiskDevice uses qemu_args() not xml(); xml() must return an empty list
+    so no spurious entries appear in the libvirt <devices> section."""
+    d = _device(delegate=mock_device_delegate)
+    assert d.xml(device_context) == []
+
+
+def test_qemu_args_single_target_single_lun():
+    """A single target with one LUN emits one -iscsi flag, one virtio-scsi-pci
+    controller, one -drive, and one scsi-block device."""
+    d = _device()
+    args = d.qemu_args(CTX_Q35)
+
+    assert "-iscsi" in args
+    idx = args.index("-iscsi")
+    assert args[idx + 1] == f"initiator-name={VALID_IQN_INITIATOR}"
+
+    device_args = [args[i + 1] for i, a in enumerate(args) if a == "-device"]
+    assert any("virtio-scsi-pci" in a for a in device_args)
+    assert any("scsi-block" in a for a in device_args)
+
+    drive_args = [args[i + 1] for i, a in enumerate(args) if a == "-drive"]
+    assert any(PORTAL_V4 in a and VALID_IQN_TARGET in a for a in drive_args)
+
+
+def test_qemu_args_multiple_targets():
+    """With N targets (each with one LUN) the device emits N -drive/-device
+    scsi-block pairs, all sharing one virtio-scsi-pci controller."""
+    iqns = [
+        "iqn.2026-06.net.ixsystems.tnguest:ha000-d000",
+        "iqn.2026-06.net.ixsystems.tnguest:ha000-d001",
+        "iqn.2026-06.net.ixsystems.tnguest:ha000-d002",
+    ]
+    d = _device(targets=[ISCSIDiskTarget(iqn=q) for q in iqns])
+    args = d.qemu_args(CTX_Q35)
+
+    drive_args = [args[i + 1] for i, a in enumerate(args) if a == "-drive"]
+    assert len(drive_args) == 3
+    for iqn in iqns:
+        assert any(iqn in a for a in drive_args)
+
+    scsi_block_args = [
+        args[i + 1] for i, a in enumerate(args)
+        if a == "-device" and "scsi-block" in args[i + 1]
+    ]
+    assert len(scsi_block_args) == 3
+    controller_id = f"scsi-iscsi-{0x15:x}"
+    assert all(f"bus={controller_id}.0" in a for a in scsi_block_args)
+
+
+def test_qemu_args_multiple_luns_per_target():
+    """Multiple LUNs on one target each produce a separate -drive/-device pair."""
+    d = _device(targets=[ISCSIDiskTarget(iqn=VALID_IQN_TARGET, luns=[0, 1, 2])])
+    args = d.qemu_args(CTX_Q35)
+
+    drive_args = [args[i + 1] for i, a in enumerate(args) if a == "-drive"]
+    assert len(drive_args) == 3
+    assert any("/0," in a or a.endswith("/0") for a in drive_args)
+    assert any("/1," in a or a.endswith("/1") for a in drive_args)
+    assert any("/2," in a or a.endswith("/2") for a in drive_args)
+
+
+def test_qemu_args_custom_slot():
+    """controller_slot controls both the PCI addr= value and the controller ID
+    embedded in device/bus references, allowing multiple iSCSI devices to
+    coexist on the root bus without address conflicts."""
+    d = _device(controller_slot=0x10)
+    args = d.qemu_args(CTX_Q35)
+    device_args = [args[i + 1] for i, a in enumerate(args) if a == "-device"]
+    assert any("addr=0x10" in a for a in device_args)
+    assert any("scsi-iscsi-10" in a for a in device_args)
+
+
+@pytest.mark.parametrize("ctx,expected_bus", [
+    # q35 is PCIe-native
+    (CTX_Q35,     "pcie.0"),
+    # aarch64 virt machine is also PCIe-native (pcie-root), not i440fx
+    (CTX_VIRT,    "pcie.0"),
+    # i440fx uses the legacy PCI root bus
+    (CTX_I440FX,  "pci.0"),
+    # unknown machine type defaults conservatively to pci.0
+    (CTX_UNKNOWN, "pci.0"),
+])
+def test_qemu_args_root_bus(ctx, expected_bus):
+    """The virtio-scsi-pci controller is attached to the correct root bus for
+    each machine type: pcie.0 for q35 and aarch64 virt, pci.0 otherwise."""
+    d = _device()
+    args = d.qemu_args(ctx)
+    device_args = [args[i + 1] for i, a in enumerate(args) if a == "-device"]
+    controller_args = [a for a in device_args if "virtio-scsi-pci" in a]
+    assert len(controller_args) == 1
+    assert f"bus={expected_bus}" in controller_args[0]
+
+
+def test_qemu_args_ipv6_portal():
+    """IPv6 portal addresses are bracketed in the iSCSI URI as required by
+    RFC 3986 (e.g. iscsi://[2001:db8::1]/iqn.../0)."""
+    d = _device(portal_address=PORTAL_V6)
+    args = d.qemu_args(CTX_Q35)
+    drive_args = [args[i + 1] for i, a in enumerate(args) if a == "-drive"]
+    assert all(f"[{PORTAL_V6}]" in a for a in drive_args)
+
+
+def test_pci_slot():
+    """pci_slot() returns (0, controller_slot) -- bus 0 is the root bus, so the
+    conflict checker can detect clashes between the iSCSI controller and NICs
+    pinned to the root bus."""
+    d = _device(controller_slot=0x15)
+    assert d.pci_slot() == (0, 0x15)
+
+
+def test_identity():
+    """identity() returns a string incorporating portal_address and the first
+    target IQN, uniquely identifying the attachment within a VM's device list."""
+    d = _device()
+    assert d.identity() == f"iscsi:{PORTAL_V4}:{VALID_IQN_TARGET}"
+
+
+def test_is_available():
+    """is_available_impl() returns True unconditionally; reachability of the
+    iSCSI target is not checked at device-creation time."""
+    d = _device()
+    assert d.is_available_impl() is True
+
+
+def test_iscsi_disk_target_default_luns():
+    """ISCSIDiskTarget defaults to luns=[0] when not specified."""
+    t = ISCSIDiskTarget(iqn=VALID_IQN_TARGET)
+    assert t.luns == [0]
+
+
+@pytest.mark.parametrize("portal_address,targets,initiator_iqn,controller_slot,expected_errors", [
+    # valid
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 0x15, []),
+    # valid IPv6
+    (PORTAL_V6, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 0x15, []),
+    # bad IP
+    ("not-an-ip", [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 0x15, ["portal_address"]),
+    # empty targets list
+    (PORTAL_V4, [], VALID_IQN_INITIATOR, 0x15, ["targets"]),
+    # malformed target IQN
+    (PORTAL_V4, [ISCSIDiskTarget(iqn="not-an-iqn")], VALID_IQN_INITIATOR, 0x15, ["targets.0.iqn"]),
+    # empty luns list on a target
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET, luns=[])], VALID_IQN_INITIATOR, 0x15, ["targets.0.luns"]),
+    # negative lun
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET, luns=[-1])], VALID_IQN_INITIATOR, 0x15, ["targets.0.luns.0"]),
+    # malformed initiator IQN
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], "not-an-iqn", 0x15, ["initiator_iqn"]),
+    # controller_slot = 0 (below minimum)
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 0, ["controller_slot"]),
+    # controller_slot = 31 (above maximum)
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 31, ["controller_slot"]),
+])
+def test_validate(portal_address, targets, initiator_iqn, controller_slot, expected_errors, mock_device_delegate):
+    """validate_impl() catches invalid addresses, malformed IQNs, empty/negative
+    LUN lists, and out-of-range controller slots; valid configs produce no errors."""
+    d = ISCSIDiskDevice(
+        portal_address=portal_address,
+        targets=targets,
+        initiator_iqn=initiator_iqn,
+        controller_slot=controller_slot,
+        device_delegate=mock_device_delegate,
+    )
+    errors = d.validate()
+    error_fields = [e[0] for e in errors]
+    for f in expected_errors:
+        assert f in error_fields, f"Expected error on '{f}', got: {errors}"
+    if not expected_errors:
+        assert errors == [], f"Expected no errors, got: {errors}"

--- a/tests/device/test_nic.py
+++ b/tests/device/test_nic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 from xml.etree import ElementTree as ET
 
-from truenas_pylibvirt.device import NICDevice, NICDeviceType, NICDeviceModel
+from truenas_pylibvirt.device import NICDevice, NICDeviceType, NICDeviceModel, PciAddress
 
 
 @pytest.mark.parametrize("type_,source,model,mac,trust_guest,expected_xml", [
@@ -187,3 +187,28 @@ def test_nic_device_validation(type_, source, model, mac, trust_guest, expected_
         # Filter out any errors from the mock delegate
         validation_errors = [e for e in errors if 'trust_guest_rx_filters' in e[0] or 'mac' in e[0]]
         assert len(validation_errors) == 0, f"Unexpected validation errors: {validation_errors}"
+
+
+def test_nic_pci_slot_without_pci_address(mock_device_delegate):
+    """NIC devices without an explicit pci_address return None from pci_slot(),
+    meaning they are excluded from cross-device PCI conflict checks."""
+    device = NICDevice(
+        type_=NICDeviceType.BRIDGE, source="br0",
+        model=NICDeviceModel.VIRTIO, mac=None,
+        trust_guest_rx_filters=False,
+        device_delegate=mock_device_delegate,
+    )
+    assert device.pci_slot() is None
+
+
+def test_nic_pci_slot_with_pci_address(mock_device_delegate):
+    """NIC devices with a pci_address return (bus, slot), which is used by the
+    cross-device conflict checker to detect collisions."""
+    device = NICDevice(
+        type_=NICDeviceType.BRIDGE, source="br0",
+        model=NICDeviceModel.VIRTIO, mac=None,
+        trust_guest_rx_filters=False,
+        pci_address=PciAddress(bus=1, slot=3),
+        device_delegate=mock_device_delegate,
+    )
+    assert device.pci_slot() == (1, 3)

--- a/tests/device/test_nic.py
+++ b/tests/device/test_nic.py
@@ -5,6 +5,7 @@ import pytest
 from xml.etree import ElementTree as ET
 
 from truenas_pylibvirt.device import NICDevice, NICDeviceType, NICDeviceModel, PciAddress
+from truenas_pylibvirt.domain.start_validator import pci_slot_error_for_machine
 
 
 @pytest.mark.parametrize("type_,source,model,mac,trust_guest,expected_xml", [
@@ -212,3 +213,61 @@ def test_nic_pci_slot_with_pci_address(mock_device_delegate):
         device_delegate=mock_device_delegate,
     )
     assert device.pci_slot() == (1, 3)
+
+
+@pytest.mark.parametrize("pci_address,expected_error_fields", [
+    # valid: bus >= 1, domain 0, function 0
+    (PciAddress(bus=1, slot=0), []),
+    # domain != 0
+    (PciAddress(bus=1, slot=0, domain=1), ['pci_address.domain']),
+    # bus == 0 (root bus)
+    (PciAddress(bus=0, slot=1), ['pci_address.bus']),
+    # function != 0
+    (PciAddress(bus=1, slot=0, function=1), ['pci_address.function']),
+    # all three invalid at once
+    (PciAddress(bus=0, slot=0, domain=1, function=2), [
+        'pci_address.domain', 'pci_address.bus', 'pci_address.function',
+    ]),
+])
+def test_nic_pci_address_validate_impl(pci_address, expected_error_fields, mock_device_delegate):
+    """validate_impl() catches PciAddress fields that are invalid regardless of machine type:
+    domain must be 0, bus must be >= 1 (root bus is too crowded), function must be 0."""
+    device = NICDevice(
+        type_=NICDeviceType.BRIDGE, source="br0",
+        model=NICDeviceModel.VIRTIO, mac=None,
+        trust_guest_rx_filters=False,
+        pci_address=pci_address,
+        device_delegate=mock_device_delegate,
+    )
+    errors = device.validate()
+    error_fields = [e[0] for e in errors]
+    for f in expected_error_fields:
+        assert f in error_fields, f"Expected error on '{f}', got: {errors}"
+    if not expected_error_fields:
+        pci_errors = [e for e in errors if e[0].startswith('pci_address')]
+        assert pci_errors == [], f"Unexpected pci_address errors: {pci_errors}"
+
+
+@pytest.mark.parametrize("slot,machine_type,expect_error,error_fragment", [
+    # PCIe (q35): slot 0 is the only valid slot on a pcie-root-port
+    (0, "pc-q35-10.0",  False, None),
+    (1, "pc-q35-10.0",  True,  "slot must be 0"),
+    # PCIe (aarch64 virt): same rules as q35
+    (0, "virt-9.2",     False, None),
+    (1, "virt-9.2",     True,  "slot must be 0"),
+    # i440fx: slot 0 is SHPC-reserved
+    (0, "pc-i440fx-9.2", True,  "usable slots start at 1"),
+    (1, "pc-i440fx-9.2", False, None),
+    # unknown machine type treated conservatively as i440fx
+    (0, None,            True,  "usable slots start at 1"),
+    (1, None,            False, None),
+])
+def test_pci_slot_error_for_machine(slot, machine_type, expect_error, error_fragment):
+    """pci_slot_error_for_machine() enforces PCIe point-to-point (slot == 0) and
+    i440fx SHPC-reserved (slot != 0) rules; unknown machine type defaults to i440fx."""
+    result = pci_slot_error_for_machine(slot, machine_type)
+    if expect_error:
+        assert result is not None
+        assert error_fragment in result
+    else:
+        assert result is None

--- a/tests/domain/test_start_validator.py
+++ b/tests/domain/test_start_validator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
-from truenas_pylibvirt.domain.start_validator import StartValidator, StartValidationContext
+from truenas_pylibvirt.domain.start_validator import StartValidator, StartValidationContext, check_pci_slot_conflicts
 from truenas_pylibvirt.device.manager import DeviceManager
 
 
@@ -91,3 +91,70 @@ def test_start_validator_accumulates_errors(mock_connection):
 
     # Should have errors from both devices
     assert len(errors) == 2
+
+
+def test_check_pci_slot_conflicts_no_conflict():
+    """Devices on distinct (bus, slot) pairs produce no errors."""
+    d1 = Mock()
+    d1.pci_slot.return_value = (0, 5)
+    d1.identity.return_value = "dev1"
+    d2 = Mock()
+    d2.pci_slot.return_value = (0, 6)
+    d2.identity.return_value = "dev2"
+    assert check_pci_slot_conflicts([d1, d2]) == []
+
+
+def test_check_pci_slot_conflicts_same_slot():
+    """Two devices claiming the same (bus, slot) produce an error naming both
+    the conflicting device and the one that already holds the slot."""
+    d1 = Mock()
+    d1.pci_slot.return_value = (0, 5)
+    d1.identity.return_value = "dev1"
+    d2 = Mock()
+    d2.pci_slot.return_value = (0, 5)
+    d2.identity.return_value = "dev2"
+    errors = check_pci_slot_conflicts([d1, d2])
+    assert len(errors) == 1
+    assert "dev2" in errors[0][0]
+    assert "bus 0" in errors[0][1] and "slot 5" in errors[0][1]
+    assert "dev1" in errors[0][1]
+
+
+def test_check_pci_slot_conflicts_different_buses():
+    """The same slot number on different buses is not a conflict."""
+    d1 = Mock()
+    d1.pci_slot.return_value = (0, 5)
+    d1.identity.return_value = "dev1"
+    d2 = Mock()
+    d2.pci_slot.return_value = (1, 5)
+    d2.identity.return_value = "dev2"
+    assert check_pci_slot_conflicts([d1, d2]) == []
+
+
+def test_check_pci_slot_conflicts_none_excluded():
+    """Devices returning None from pci_slot() are excluded from conflict checks."""
+    d1 = Mock()
+    d1.pci_slot.return_value = None
+    d2 = Mock()
+    d2.pci_slot.return_value = None
+    assert check_pci_slot_conflicts([d1, d2]) == []
+
+
+def test_start_validator_reports_pci_slot_conflict(mock_connection):
+    """StartValidator.validate() includes PCI slot conflicts alongside other
+    per-device errors."""
+    d1 = Mock()
+    d1.is_available.return_value = True
+    d1.validate_start.return_value = []
+    d1.pci_slot.return_value = (0, 5)
+    d1.identity.return_value = "dev1"
+    d2 = Mock()
+    d2.is_available.return_value = True
+    d2.validate_start.return_value = []
+    d2.pci_slot.return_value = (0, 5)
+    d2.identity.return_value = "dev2"
+
+    validator = StartValidator()
+    context = StartValidationContext(connection=mock_connection, domain_uuid="test-uuid")
+    errors = validator.validate([d1, d2], context)
+    assert any("slot 5" in e[1] for e in errors)

--- a/truenas_pylibvirt/device/__init__.py
+++ b/truenas_pylibvirt/device/__init__.py
@@ -5,6 +5,7 @@ from .delegate import DeviceDelegate  # noqa
 from .display import DisplayDevice, DisplayDeviceType  # noqa
 from .filesystem import FilesystemDevice # noqa
 from .gpu import GPUDevice  # noqa
+from .iscsi_disk import ISCSIDiskDevice, ISCSIDiskTarget  # noqa
 from .nic import NICDevice, NICDeviceType, NICDeviceModel, PciAddress  # noqa
 from .pci import PCIDevice  # noqa
 from .storage import DiskStorageDevice, RawStorageDevice, StorageDeviceType, StorageDeviceIoType  # noqa
@@ -19,6 +20,8 @@ __all__ = [
     'DisplayDeviceType',
     'FilesystemDevice',
     'GPUDevice',
+    'ISCSIDiskDevice',
+    'ISCSIDiskTarget',
     'NICDevice',
     'NICDeviceModel',
     'NICDeviceType',

--- a/truenas_pylibvirt/device/base.py
+++ b/truenas_pylibvirt/device/base.py
@@ -25,6 +25,13 @@ class DeviceXmlContext:
     counters: Counters
 
 
+@dataclass
+class QemuArgsContext:
+    # Machine type string as passed to libvirt (e.g. 'pc-q35-10.0', 'virt-9.2').
+    # None means unknown / caller did not specify.
+    machine_type: str | None = None
+
+
 @dataclass(kw_only=True)
 class Device(ABC):
 
@@ -64,6 +71,16 @@ class Device(ABC):
 
     def validate_impl(self) -> list[tuple[str, str]]:
         return []
+
+    def qemu_args(self, context: QemuArgsContext) -> list[str]:
+        # For device types that libvirt cannot model natively; args are injected
+        # into <qemu:commandline> alongside command_line_args.
+        return []
+
+    def pci_slot(self) -> tuple[int, int] | None:
+        # Returns (bus, slot) for devices with an explicit PCI placement.
+        # Used by check_pci_slot_conflicts() to detect cross-device collisions.
+        return None
 
     def validate_start(self, context: StartValidationContext) -> list[tuple[str, str]]:
         """

--- a/truenas_pylibvirt/device/iscsi_disk.py
+++ b/truenas_pylibvirt/device/iscsi_disk.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass, field
+from xml.etree import ElementTree
+
+from .base import Device, DeviceXmlContext, QemuArgsContext
+
+
+# RFC 3720 IQN: iqn.YYYY-MM.<reversed-domain>[:<suffix>]
+IQN_RE = re.compile(r'^iqn\.\d{4}-\d{2}\.[a-zA-Z][a-zA-Z0-9\-\.]*(?::[^\s]*)?$')
+
+
+@dataclass
+class ISCSIDiskTarget:
+    iqn: str
+    luns: list[int] = field(default_factory=lambda: [0])
+
+
+@dataclass(kw_only=True)
+class ISCSIDiskDevice(Device):
+    """iSCSI disks attached via QEMU's built-in initiator (block-iscsi.so).
+
+    Libvirt has no native model for this; args are emitted via qemu_args()
+    and injected into <qemu:commandline> at domain XML generation time.
+    Each instance manages one virtio-scsi-pci controller and all disks
+    behind it.  Use controller_slot to avoid PCI address conflicts with
+    other devices on the root bus.
+    """
+
+    portal_address: str
+    targets: list[ISCSIDiskTarget]
+    initiator_iqn: str
+    # PCI slot for the virtio-scsi-pci controller on the root bus (default avoids
+    # common libvirt auto-assignments and the installer NIC at 0x1e).
+    controller_slot: int = 0x15
+
+    def xml(self, context: DeviceXmlContext) -> list[ElementTree.Element]:
+        return []
+
+    def qemu_args(self, context: QemuArgsContext) -> list[str]:
+        mt = context.machine_type or ''
+        # q35 and aarch64 virt are both PCIe-native (pcie-root); i440fx uses pci.0.
+        root_bus = 'pcie.0' if ('q35' in mt or mt.startswith('virt')) else 'pci.0'
+        # IPv6 addresses must be bracketed in iSCSI URIs.
+        try:
+            addr = ipaddress.ip_address(self.portal_address)
+            portal = f"[{self.portal_address}]" if isinstance(addr, ipaddress.IPv6Address) else self.portal_address
+        except ValueError:
+            portal = self.portal_address
+        controller_id = f"scsi-iscsi-{self.controller_slot:x}"
+        args = [
+            "-iscsi", f"initiator-name={self.initiator_iqn}",
+            "-device",
+            f"virtio-scsi-pci,id={controller_id},bus={root_bus},addr=0x{self.controller_slot:x}",
+        ]
+        drive_index = 0
+        for target in self.targets:
+            for lun in target.luns:
+                drive_id = f"iscsi-{self.controller_slot:x}-{drive_index}"
+                args += [
+                    "-drive",
+                    f"file=iscsi://{portal}/{target.iqn}/{lun}"
+                    f",if=none,id={drive_id},format=raw,cache=none",
+                    "-device", f"scsi-block,drive={drive_id},bus={controller_id}.0",
+                ]
+                drive_index += 1
+        return args
+
+    def pci_slot(self) -> tuple[int, int] | None:
+        # Always placed on the root bus (bus index 0).
+        return (0, self.controller_slot)
+
+    def is_available_impl(self) -> bool:
+        return True
+
+    def identity_impl(self) -> str:
+        first_iqn = self.targets[0].iqn if self.targets else ""
+        return f"iscsi:{self.portal_address}:{first_iqn}"
+
+    def validate_impl(self) -> list[tuple[str, str]]:
+        verrors = []
+
+        try:
+            ipaddress.ip_address(self.portal_address)
+        except ValueError:
+            verrors.append(('portal_address', 'Must be a valid IPv4 or IPv6 address.'))
+
+        if not self.targets:
+            verrors.append(('targets', 'At least one target is required.'))
+        else:
+            for i, target in enumerate(self.targets):
+                if not IQN_RE.match(target.iqn):
+                    verrors.append((f'targets.{i}.iqn', f'Invalid IQN: {target.iqn!r}'))
+                if not target.luns:
+                    verrors.append((f'targets.{i}.luns', 'At least one LUN is required.'))
+                else:
+                    for j, lun in enumerate(target.luns):
+                        if lun < 0:
+                            verrors.append((f'targets.{i}.luns.{j}', 'LUN must be >= 0.'))
+
+        if not self.initiator_iqn:
+            verrors.append(('initiator_iqn', 'This field is required.'))
+        elif not IQN_RE.match(self.initiator_iqn):
+            verrors.append(('initiator_iqn', f'Invalid IQN: {self.initiator_iqn!r}'))
+
+        if not (1 <= self.controller_slot <= 30):
+            verrors.append(('controller_slot', 'Must be between 1 and 30 inclusive.'))
+
+        return verrors

--- a/truenas_pylibvirt/device/nic.py
+++ b/truenas_pylibvirt/device/nic.py
@@ -124,6 +124,11 @@ class NICDevice(Device):
                     nic_attach = default_route.oif_name
         return nic_attach
 
+    def pci_slot(self) -> tuple[int, int] | None:
+        if self.pci_address:
+            return (self.pci_address.bus, self.pci_address.slot)
+        return None
+
     def validate_impl(self) -> list[tuple[str, str]]:
         verrors = []
         if self.source and self.source.startswith('br') and self.trust_guest_rx_filters:

--- a/truenas_pylibvirt/device/nic.py
+++ b/truenas_pylibvirt/device/nic.py
@@ -150,4 +150,24 @@ class NICDevice(Device):
                 verrors.append(
                     ('mac', 'MAC address must not start with `ff`')
                 )
+
+        if self.pci_address:
+            if self.pci_address.domain != 0:
+                verrors.append((
+                    'pci_address.domain',
+                    'PCI domain must be 0; multi-segment topologies are not supported',
+                ))
+            if self.pci_address.bus == 0:
+                verrors.append((
+                    'pci_address.bus',
+                    'Bus 0 is the root bus; NICs must be placed on a controller bus (>= 1) '
+                    'to avoid conflicts with platform devices',
+                ))
+            if self.pci_address.function != 0:
+                verrors.append((
+                    'pci_address.function',
+                    'Only function 0 is supported; function > 0 requires multifunction=on '
+                    'on function 0, which is not currently emitted',
+                ))
+
         return verrors

--- a/truenas_pylibvirt/domain/start_validator.py
+++ b/truenas_pylibvirt/domain/start_validator.py
@@ -16,6 +16,22 @@ class StartValidationContext:
     domain_uuid: str
 
 
+def pci_slot_error_for_machine(slot: int, machine_type: str | None) -> str | None:
+    """Return an error string if slot violates the machine topology PCI slot rules, else None.
+
+    PCIe (q35 / aarch64 virt): ports are point-to-point, so slot must be 0.
+    i440fx (PCI bridge): slot 0 is the SHPC controller; usable slots start at 1.
+    Unknown machine type is treated conservatively as i440fx.
+    """
+    mt = machine_type or ''
+    is_pcie = 'q35' in mt or mt.startswith('virt')
+    if is_pcie and slot != 0:
+        return 'PCIe machines (q35 / aarch64 virt) use point-to-point ports; slot must be 0'
+    if not is_pcie and slot == 0:
+        return 'Slot 0 is reserved (SHPC controller) on i440fx PCI bridges; usable slots start at 1'
+    return None
+
+
 def check_pci_slot_conflicts(devices: list[Device]) -> list[tuple[str, str]]:
     """Return (field, error) pairs for any two devices claiming the same (bus, slot).
 

--- a/truenas_pylibvirt/domain/start_validator.py
+++ b/truenas_pylibvirt/domain/start_validator.py
@@ -16,6 +16,28 @@ class StartValidationContext:
     domain_uuid: str
 
 
+def check_pci_slot_conflicts(devices: list[Device]) -> list[tuple[str, str]]:
+    """Return (field, error) pairs for any two devices claiming the same (bus, slot).
+
+    Only devices that return a non-None pci_slot() participate in the check.
+    """
+    seen: dict[tuple[int, int], str] = {}
+    errors = []
+    for device in devices:
+        slot = device.pci_slot()
+        if slot is None:
+            continue
+        identity = device.identity()
+        if slot in seen:
+            errors.append((
+                f'device.{identity}',
+                f'PCI bus {slot[0]} slot {slot[1]} already claimed by {seen[slot]}',
+            ))
+        else:
+            seen[slot] = identity
+    return errors
+
+
 class StartValidator:
     """Validates domain can start - checks for conflicts, availability, etc."""
 
@@ -35,5 +57,7 @@ class StartValidator:
 
             device_errors = device.validate_start(context)
             errors.extend(device_errors)
+
+        errors.extend(check_pci_slot_conflicts(devices))
 
         return errors

--- a/truenas_pylibvirt/domain/vm/xml.py
+++ b/truenas_pylibvirt/domain/vm/xml.py
@@ -5,6 +5,7 @@ import shlex
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
+from ...device.base import QemuArgsContext
 from ...device.display import DisplayDevice, DisplayDeviceType
 from ...device.nic import NICDevice
 from ...utils import kvm_supported
@@ -319,13 +320,20 @@ class VmDomainXmlGenerator(BaseDomainXmlGenerator):
         return features
 
     def _misc_xml(self) -> list[ElementTree.Element]:
+        # Collect raw QEMU args from two sources: the explicit command_line_args
+        # field, and any devices whose libvirt has no native model for (e.g.
+        # ISCSIDiskDevice).  Both land in <qemu:commandline>.
+        all_args = list(shlex.split(self.domain.configuration.command_line_args))
+        ctx = QemuArgsContext(machine_type=self.domain.configuration.machine_type)
+        for device in self.domain.configuration.devices:
+            all_args.extend(device.qemu_args(ctx))
         return [
             xml_element(
                 "commandline",
                 attributes={"xmlns": "http://libvirt.org/schemas/domain/qemu/1.0"},
                 children=[
                     xml_element("arg", attributes={"value": arg})
-                    for arg in shlex.split(self.domain.configuration.command_line_args)
+                    for arg in all_args
                 ],
             ),
         ]


### PR DESCRIPTION
Introduces ISCSIDiskDevice, a first-class device type for iSCSI disks attached via QEMU's built-in initiator (block-iscsi.so). Each device manages one virtio-scsi-pci controller and a list of ISCSIDiskTarget entries (IQN + LUNs).

The implementation required a QemuArgsContext / qemu_args() parallel to DeviceXmlContext / xml() for devices that libvirt cannot model natively. The root bus (pcie.0 vs pci.0) is derived from machine_type at arg-generation time, correctly handling q35, aarch64 virt, and i440fx. IPv6 portal addresses are bracketed in iSCSI URIs as required by RFC 3986.

Also adds a pci_slot() hook to Device, implemented on NICDevice and ISCSIDiskDevice, and a check_pci_slot_conflicts() function called by StartValidator to catch cross-device slot collisions at start time.

Also validate PciAddress fields and enforce machine-topology slot rules:
- Add machine-type-independent PciAddress validation to NICDevice.validate_impl(): domain must be 0 (no multi-segment support), bus must be >= 1 (bus 0 is the root bus and conflicts with platform devices), and function must be 0 (function > 0 requires multifunction=on on function 0, which is not emitted).
- Add pci_slot_error_for_machine() to start_validator.py alongside check_pci_slot_conflicts(). Enforces machine-topology slot rules: PCIe machines (q35 / aarch64 virt) use point-to-point ports so slot must be 0; i440fx PCI bridges reserve slot 0 for the SHPC controller so usable slots start at 1. Called from VMNICDelegate.validate_middleware() in middleware with the VM's machine_type.