### PR TITLE
NAS-141862 / 27.0.0-BETA.1 / truenas_pylibvirt: Fix DomainManager running cleanup against a still-running domain

### DIFF
--- a/tests/domain/test_domain_manager_event.py
+++ b/tests/domain/test_domain_manager_event.py
@@ -1,0 +1,94 @@
+"""Regression tests for DomainManager._domain_event_callback().
+
+A stop event is delivered asynchronously by the libvirt event thread. On a
+restart (destroy + immediate start) it can arrive after start() has already
+re-created and re-tracked the domain, so the callback must re-check the live
+state and refuse to tear down a domain that is running now. It must still clean
+up when the domain is genuinely stopped or has been undefined (get_domain() ->
+None).
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+import truenas_pylibvirt.domain.manager as manager_mod
+from truenas_pylibvirt.domain.manager import DomainManager
+from truenas_pylibvirt.libvirtd.connection import DomainEvent, DomainState, VirDomainEvent
+
+
+@pytest.fixture
+def runtime_cleanup(monkeypatch):
+    cleanup = Mock()
+    monkeypatch.setattr(manager_mod.runtime, "cleanup_for_uuid", cleanup)
+    return cleanup
+
+
+def _event(uuid: str = "uuid-1", event: VirDomainEvent = VirDomainEvent.STOPPED) -> DomainEvent:
+    return DomainEvent(event=event, uuid=uuid)
+
+
+def test_stale_stop_event_does_not_tear_down_running_domain(mock_connection, runtime_cleanup):
+    """A stop event delivered after a restart re-created the domain must not
+    clean up the freshly started, still-running instance nor unmount its runtime
+    state."""
+    manager = DomainManager(mock_connection)
+    tracked = Mock()  # the newly started StartedDomain
+    manager.started_domains["uuid-1"] = tracked
+
+    mock_connection.get_domain.return_value = Mock()  # domain exists...
+    mock_connection.domain_state.return_value = DomainState.RUNNING  # ...and is running
+
+    manager._domain_event_callback(_event("uuid-1", VirDomainEvent.STOPPED))
+
+    assert manager.started_domains["uuid-1"] is tracked
+    tracked.cleanup.assert_not_called()
+    runtime_cleanup.assert_not_called()
+
+
+def test_stop_event_for_stopped_domain_cleans_up(mock_connection, runtime_cleanup):
+    """A genuine stop (domain now SHUTOFF) cleans up tracking and reconciles
+    durable runtime state."""
+    manager = DomainManager(mock_connection)
+    tracked = Mock()
+    manager.started_domains["uuid-1"] = tracked
+
+    mock_connection.get_domain.return_value = Mock()
+    mock_connection.domain_state.return_value = DomainState.SHUTOFF
+
+    manager._domain_event_callback(_event("uuid-1", VirDomainEvent.STOPPED))
+
+    assert "uuid-1" not in manager.started_domains
+    tracked.cleanup.assert_called_once()
+    runtime_cleanup.assert_called_once_with("uuid-1")
+
+
+def test_undefined_event_with_missing_domain_cleans_up(mock_connection, runtime_cleanup):
+    """An UNDEFINED event (domain gone, get_domain() -> None) must still clean
+    up, not skip because the domain lookup returned None."""
+    manager = DomainManager(mock_connection)
+    tracked = Mock()
+    manager.started_domains["uuid-1"] = tracked
+
+    mock_connection.get_domain.return_value = None
+
+    manager._domain_event_callback(_event("uuid-1", VirDomainEvent.UNDEFINED))
+
+    assert "uuid-1" not in manager.started_domains
+    tracked.cleanup.assert_called_once()
+    runtime_cleanup.assert_called_once_with("uuid-1")
+
+
+def test_non_stop_event_is_ignored(mock_connection, runtime_cleanup):
+    """Non-stop events (e.g. STARTED) do nothing and never query libvirt."""
+    manager = DomainManager(mock_connection)
+    tracked = Mock()
+    manager.started_domains["uuid-1"] = tracked
+
+    manager._domain_event_callback(_event("uuid-1", VirDomainEvent.STARTED))
+
+    assert manager.started_domains["uuid-1"] is tracked
+    tracked.cleanup.assert_not_called()
+    runtime_cleanup.assert_not_called()
+    mock_connection.get_domain.assert_not_called()

--- a/tests/domain/test_domain_manager_event.py
+++ b/tests/domain/test_domain_manager_event.py
@@ -11,11 +11,18 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import libvirt
 import pytest
 
 import truenas_pylibvirt.domain.manager as manager_mod
 from truenas_pylibvirt.domain.manager import DomainManager
 from truenas_pylibvirt.libvirtd.connection import DomainEvent, DomainState, VirDomainEvent
+
+
+def _libvirt_error(code: int) -> libvirt.libvirtError:
+    e = libvirt.libvirtError("error")
+    e.err = (code, None, "message", None, None, None, None, -1, -1)
+    return e
 
 
 @pytest.fixture
@@ -78,6 +85,42 @@ def test_undefined_event_with_missing_domain_cleans_up(mock_connection, runtime_
     assert "uuid-1" not in manager.started_domains
     tracked.cleanup.assert_called_once()
     runtime_cleanup.assert_called_once_with("uuid-1")
+
+
+def test_stop_event_when_domain_vanishes_mid_state_query_cleans_up(mock_connection, runtime_cleanup):
+    """The domain can be undefined between get_domain() and the state query;
+    VIR_ERR_NO_DOMAIN there means gone, so clean up as for a missing domain."""
+    manager = DomainManager(mock_connection)
+    tracked = Mock()
+    manager.started_domains["uuid-1"] = tracked
+
+    mock_connection.get_domain.return_value = Mock()  # still there at lookup...
+    mock_connection.domain_state.side_effect = _libvirt_error(libvirt.VIR_ERR_NO_DOMAIN)  # ...gone at query
+
+    manager._domain_event_callback(_event("uuid-1", VirDomainEvent.STOPPED))
+
+    assert "uuid-1" not in manager.started_domains
+    tracked.cleanup.assert_called_once()
+    runtime_cleanup.assert_called_once_with("uuid-1")
+
+
+def test_stop_event_with_other_libvirt_error_propagates_without_cleanup(mock_connection, runtime_cleanup):
+    """A state-query failure other than NO_DOMAIN says nothing about whether the
+    domain is stopped, so it must propagate rather than trigger teardown of a
+    possibly-running domain."""
+    manager = DomainManager(mock_connection)
+    tracked = Mock()
+    manager.started_domains["uuid-1"] = tracked
+
+    mock_connection.get_domain.return_value = Mock()
+    mock_connection.domain_state.side_effect = _libvirt_error(libvirt.VIR_ERR_INTERNAL_ERROR)
+
+    with pytest.raises(libvirt.libvirtError):
+        manager._domain_event_callback(_event("uuid-1", VirDomainEvent.STOPPED))
+
+    assert manager.started_domains["uuid-1"] is tracked
+    tracked.cleanup.assert_not_called()
+    runtime_cleanup.assert_not_called()
 
 
 def test_non_stop_event_is_ignored(mock_connection, runtime_cleanup):

--- a/tests/domain/test_domain_manager_start.py
+++ b/tests/domain/test_domain_manager_start.py
@@ -1,0 +1,88 @@
+"""Regression tests for DomainManager.start()'s handling of a domain that is
+already present in `started_domains`.
+
+The dangerous case is a second start() on a domain that is still running: the
+entry must stay tracked and must NOT be cleaned up. Dropping it there leaves its
+ExitStack to garbage collection, whose device finalizers terminate the display
+proxy and unmount a running container's bind mounts (libvirt refuses the managed
+PCI reattach while the device is still assigned to the running domain).
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from truenas_pylibvirt.domain.manager import DomainManager
+from truenas_pylibvirt.libvirtd.connection import DomainState
+from truenas_pylibvirt.error import Error
+
+
+def _domain(uuid: str = "uuid-1", name: str = "testvm") -> Mock:
+    domain = Mock()
+    domain.configuration.uuid = uuid
+    domain.configuration.name = name
+    domain.device_manager.devices = []
+    return domain
+
+
+@pytest.mark.parametrize("active_state", [DomainState.RUNNING, DomainState.PAUSED])
+def test_start_on_active_domain_keeps_tracking_and_does_not_clean_up(mock_connection, active_state):
+    """A second start() on an already-active tracked domain raises, keeps the
+    entry in started_domains, and never tears down its staging."""
+    manager = DomainManager(mock_connection)
+    domain = _domain()
+
+    tracked = Mock()  # stand-in for the live StartedDomain
+    manager.started_domains[domain.configuration.uuid] = tracked
+
+    mock_connection.get_domain.return_value = Mock()  # libvirt still has the domain
+    mock_connection.domain_state.return_value = active_state
+
+    with pytest.raises(Error, match="already started"):
+        manager.start(domain)
+
+    # Still tracked (so the eventual STOPPED event can clean it up), never GC-leaked.
+    assert manager.started_domains[domain.configuration.uuid] is tracked
+    tracked.cleanup.assert_not_called()
+
+
+def test_start_when_libvirt_domain_missing_cleans_up_stale_entry(mock_connection):
+    """A tracked entry whose libvirt domain has vanished (get_domain() -> None)
+    is cleaned up and removed explicitly, not silently dropped to GC."""
+    manager = DomainManager(mock_connection)
+    domain = _domain()
+
+    stale = Mock()
+    manager.started_domains[domain.configuration.uuid] = stale
+
+    mock_connection.get_domain.return_value = None
+    # Short-circuit right after the stale-entry handling so the full define/create
+    # tail does not need mocking.
+    manager.start_validator.validate = Mock(return_value=[("field", "boom")])
+
+    with pytest.raises(Error, match="Cannot start"):
+        manager.start(domain)
+
+    stale.cleanup.assert_called_once()
+    assert domain.configuration.uuid not in manager.started_domains
+
+
+def test_start_when_tracked_but_stopped_cleans_up_and_removes(mock_connection):
+    """A tracked entry whose domain is actually stopped is cleaned up and removed
+    before the start proceeds (here short-circuited at validation)."""
+    manager = DomainManager(mock_connection)
+    domain = _domain()
+
+    stale = Mock()
+    manager.started_domains[domain.configuration.uuid] = stale
+
+    mock_connection.get_domain.return_value = Mock()
+    mock_connection.domain_state.return_value = DomainState.SHUTOFF
+    manager.start_validator.validate = Mock(return_value=[("field", "boom")])
+
+    with pytest.raises(Error, match="Cannot start"):
+        manager.start(domain)
+
+    stale.cleanup.assert_called_once()
+    assert domain.configuration.uuid not in manager.started_domains

--- a/tests/domain/test_domain_manager_start.py
+++ b/tests/domain/test_domain_manager_start.py
@@ -11,11 +11,18 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+import libvirt
 import pytest
 
 from truenas_pylibvirt.domain.manager import DomainManager
 from truenas_pylibvirt.libvirtd.connection import DomainState
 from truenas_pylibvirt.error import Error
+
+
+def _no_domain_error() -> libvirt.libvirtError:
+    e = libvirt.libvirtError("error")
+    e.err = (libvirt.VIR_ERR_NO_DOMAIN, None, "message", None, None, None, None, -1, -1)
+    return e
 
 
 def _domain(uuid: str = "uuid-1", name: str = "testvm") -> Mock:
@@ -59,6 +66,28 @@ def test_start_when_libvirt_domain_missing_cleans_up_stale_entry(mock_connection
     mock_connection.get_domain.return_value = None
     # Short-circuit right after the stale-entry handling so the full define/create
     # tail does not need mocking.
+    manager.start_validator.validate = Mock(return_value=[("field", "boom")])
+
+    with pytest.raises(Error, match="Cannot start"):
+        manager.start(domain)
+
+    stale.cleanup.assert_called_once()
+    assert domain.configuration.uuid not in manager.started_domains
+
+
+def test_start_when_domain_vanishes_mid_state_query_cleans_up_stale_entry(mock_connection):
+    """The domain can be undefined between get_domain() and the state query;
+    VIR_ERR_NO_DOMAIN there is handled like a missing domain: the stale entry is
+    cleaned up and the start proceeds (here short-circuited at validation)."""
+    manager = DomainManager(mock_connection)
+    domain = _domain()
+
+    stale = Mock()
+    manager.started_domains[domain.configuration.uuid] = stale
+
+    mock_connection.get_domain.return_value = Mock()  # still there at lookup...
+    mock_connection.domain_state.side_effect = _no_domain_error()  # ...gone at query
+
     manager.start_validator.validate = Mock(return_value=[("field", "boom")])
 
     with pytest.raises(Error, match="Cannot start"):

--- a/truenas_pylibvirt/domain/manager.py
+++ b/truenas_pylibvirt/domain/manager.py
@@ -8,7 +8,7 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .. import runtime
-from ..error import Error, DomainDoesNotExistError
+from ..error import Error, DomainDoesNotExistError, is_no_domain_error
 from ..libvirtd.connection import Connection, DomainEvent, DomainState, VirDomainEvent
 from .base.domain import BaseDomain
 from .start_validator import StartValidator, StartValidationContext
@@ -44,8 +44,7 @@ class DomainManager:
     def start(self, domain: BaseDomain) -> None:
         with self.started_domains_lock:
             if started_domain := self.started_domains.get(domain.configuration.uuid):
-                if libvirt_domain := self.connection.get_domain(domain.configuration.uuid):
-                    domain_state = self.connection.domain_state(libvirt_domain)
+                if (domain_state := self._current_domain_state(domain.configuration.uuid)) is not None:
                     if domain_state not in STOPPED_STATES:
                         # Still running: leave it tracked so its device staging is unwound
                         # by the eventual STOPPED event. Removing it here would drop the
@@ -166,6 +165,25 @@ class DomainManager:
 
         return libvirt_domain
 
+    def _current_domain_state(self, uuid: str) -> DomainState | None:
+        """Live state of the domain, or None if it no longer exists.
+
+        The domain can be undefined between the lookup and the state query,
+        so VIR_ERR_NO_DOMAIN from the state query means gone, the same as a
+        failed lookup.
+        """
+        libvirt_domain = self.connection.get_domain(uuid)
+        if libvirt_domain is None:
+            return None
+
+        try:
+            return self.connection.domain_state(libvirt_domain)
+        except Exception as e:
+            if is_no_domain_error(e):
+                return None
+
+            raise
+
     def _domain_event_callback(self, event: DomainEvent) -> None:
         if event.event not in STOPPED_EVENTS:
             return
@@ -176,11 +194,11 @@ class DomainManager:
             # Re-check the live state under the lock and only tear down when the
             # domain is really gone or stopped now, so a stale event cannot unwind
             # the staging (or unmount the runtime state) of the freshly started
-            # instance. get_domain() returning None means the domain was
-            # undefined -- itself a stop event -- so "missing" means clean up, not
-            # skip.
-            libvirt_domain = self.connection.get_domain(event.uuid)
-            if libvirt_domain is not None and self.connection.domain_state(libvirt_domain) not in STOPPED_STATES:
+            # instance. None means the domain no longer exists (undefined before
+            # the lookup or while querying its state) -- itself a stop event -- so
+            # "missing" means clean up, not skip.
+            domain_state = self._current_domain_state(event.uuid)
+            if domain_state is not None and domain_state not in STOPPED_STATES:
                 return
 
             # Contextmanagers unwind first and undo their own per-device staging.

--- a/truenas_pylibvirt/domain/manager.py
+++ b/truenas_pylibvirt/domain/manager.py
@@ -43,18 +43,30 @@ class DomainManager:
 
     def start(self, domain: BaseDomain) -> None:
         with self.started_domains_lock:
-            if started_domain := self.started_domains.pop(domain.configuration.uuid, None):
+            if started_domain := self.started_domains.get(domain.configuration.uuid):
                 if libvirt_domain := self.connection.get_domain(domain.configuration.uuid):
                     domain_state = self.connection.domain_state(libvirt_domain)
-                    if domain_state in STOPPED_STATES:
-                        logger.info(
-                            f"Requested to start domain {domain.configuration.name!r}. It is present in "
-                            f"`started_domains`, but its state is {domain_state!r}. This should not happen. "
-                            "Performing clean-up routing."
-                        )
-                        started_domain.cleanup()
-                    else:
+                    if domain_state not in STOPPED_STATES:
+                        # Still running: leave it tracked so its device staging is unwound
+                        # by the eventual STOPPED event. Removing it here would drop the
+                        # only reference to its ExitStack; GC then runs the device
+                        # finalizers against a live domain -- terminating the display proxy
+                        # and unmounting a running container's bind mounts. (The managed PCI
+                        # reattach is refused by libvirt while the device is in use, so the
+                        # passthrough device itself is not pulled from the guest.)
                         raise Error(f"Domain {domain.configuration.name!r} is already started ({domain_state!r}).")
+
+                    logger.info(
+                        f"Requested to start domain {domain.configuration.name!r}. It is present in "
+                        f"`started_domains`, but its state is {domain_state!r}. This should not happen. "
+                        "Performing clean-up routing."
+                    )
+
+                # Present in `started_domains` but not running (stopped out-of-band,
+                # undefined, or a missed STOPPED event). Remove and unwind its staging
+                # explicitly before re-staging below, rather than leaking it to GC.
+                self.started_domains.pop(domain.configuration.uuid, None)
+                started_domain.cleanup()
 
             validation_context = StartValidationContext(
                 connection=self.connection,
@@ -155,31 +167,41 @@ class DomainManager:
         return libvirt_domain
 
     def _domain_event_callback(self, event: DomainEvent) -> None:
-        libvirt_domain = self.connection.get_domain(event.uuid)
-        if libvirt_domain is None:
+        if event.event not in STOPPED_EVENTS:
             return
 
-        if event.event in STOPPED_EVENTS:
-            # Happy path: contextmanagers unwind first and undo their own
-            # per-device staging. Wrapped because one device's cleanup
-            # failing must not block the runtime sweep below.
-            with self.started_domains_lock:
-                if started_domain := self.started_domains.pop(event.uuid, None):
-                    try:
-                        started_domain.cleanup()
-                    except Exception:
-                        logger.exception(
-                            "StartedDomain cleanup failed for uuid %s; "
-                            "runtime sweep will reconcile",
-                            event.uuid,
-                        )
+        with self.started_domains_lock:
+            # A restart (destroy + immediate start) can deliver this stop event
+            # after start() has already re-created and re-tracked the domain.
+            # Re-check the live state under the lock and only tear down when the
+            # domain is really gone or stopped now, so a stale event cannot unwind
+            # the staging (or unmount the runtime state) of the freshly started
+            # instance. get_domain() returning None means the domain was
+            # undefined -- itself a stop event -- so "missing" means clean up, not
+            # skip.
+            libvirt_domain = self.connection.get_domain(event.uuid)
+            if libvirt_domain is not None and self.connection.domain_state(libvirt_domain) not in STOPPED_STATES:
+                return
 
-                # Authoritative reconciliation of durable runtime state.
-                # Independent of `started_domains`, which is empty after a
-                # middleware restart even when libvirt-managed containers are
-                # still running. Harmless for VMs: no `/run/truenas_containers/*`
-                # entries match their UUIDs, so this is a no-op.
+            # Contextmanagers unwind first and undo their own per-device staging.
+            # Wrapped because one device's cleanup failing must not block the
+            # runtime sweep below.
+            if started_domain := self.started_domains.pop(event.uuid, None):
                 try:
-                    runtime.cleanup_for_uuid(event.uuid)
+                    started_domain.cleanup()
                 except Exception:
-                    logger.exception("Runtime state cleanup failed for uuid %s", event.uuid)
+                    logger.exception(
+                        "StartedDomain cleanup failed for uuid %s; "
+                        "runtime sweep will reconcile",
+                        event.uuid,
+                    )
+
+            # Authoritative reconciliation of durable runtime state.
+            # Independent of `started_domains`, which is empty after a
+            # middleware restart even when libvirt-managed containers are
+            # still running. Harmless for VMs: no `/run/truenas_containers/*`
+            # entries match their UUIDs, so this is a no-op.
+            try:
+                runtime.cleanup_for_uuid(event.uuid)
+            except Exception:
+                logger.exception("Runtime state cleanup failed for uuid %s", event.uuid)


### PR DESCRIPTION
Both `start()` and `_domain_event_callback()` could run
`StartedDomain.cleanup()` (ExitStack unwind plus runtime.cleanup_for_uuid)
against a domain that is still running.
    
`start()` popped the entry from started_domains before checking state.
The "already started" branch then raised without reinserting it, and
the `get_domain() == None` branch fell through, both leaving the popped
`StartedDomain` unreferenced so GC ran the device finalizers. This commit
changes behavior so that we look it up with get() and only pop() on the
branches that call `cleanup()`.
    
`_domain_event_callback()` acted on the asynchronous stop event without
re-checking current state, so a stale `STOPPED` event -- a restart's
destroy delivered after `start()` had re-created the domain -- popped and
cleaned up the new, running instance. It also returned early on
`get_domain() == None`, the post-UNDEFINE state, so UNDEFINE events never
cleaned up. Re-check state under the lock and cleanup() only when the
domain is stopped or gone (None means gone).
    
In this situation impact could include a terminated websockify proxy, a running
container's bind mounts unmounted, and an untracked domain. 