### PR TITLE
NAS-141900 / 27.0.0-BETA.1 / iscsi_disk: prevent QEMU option injection via IQN / portal

### DIFF
--- a/tests/device/test_iscsi_disk.py
+++ b/tests/device/test_iscsi_disk.py
@@ -194,6 +194,18 @@ def test_iscsi_disk_target_default_luns():
     (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 0, ["controller_slot"]),
     # controller_slot = 31 (above maximum)
     (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)], VALID_IQN_INITIATOR, 31, ["controller_slot"]),
+    # QEMU option-string injection via comma in target IQN
+    (PORTAL_V4, [ISCSIDiskTarget(iqn="iqn.2026-06.net.x:a,readonly=on")],
+        VALID_IQN_INITIATOR, 0x15, ["targets.0.iqn"]),
+    # QEMU option-string injection via comma+file= in target IQN
+    (PORTAL_V4, [ISCSIDiskTarget(iqn="iqn.2026-06.net.x:a,file=/etc/shadow")],
+        VALID_IQN_INITIATOR, 0x15, ["targets.0.iqn"]),
+    # QEMU option-string injection via '=' in target IQN
+    (PORTAL_V4, [ISCSIDiskTarget(iqn="iqn.2026-06.net.x:a=b")],
+        VALID_IQN_INITIATOR, 0x15, ["targets.0.iqn"]),
+    # QEMU option-string injection via comma in initiator IQN
+    (PORTAL_V4, [ISCSIDiskTarget(iqn=VALID_IQN_TARGET)],
+        "iqn.2026-06.net.x:a,password=pw", 0x15, ["initiator_iqn"]),
 ])
 def test_validate(portal_address, targets, initiator_iqn, controller_slot, expected_errors, mock_device_delegate):
     """validate_impl() catches invalid addresses, malformed IQNs, empty/negative
@@ -211,3 +223,36 @@ def test_validate(portal_address, targets, initiator_iqn, controller_slot, expec
         assert f in error_fields, f"Expected error on '{f}', got: {errors}"
     if not expected_errors:
         assert errors == [], f"Expected no errors, got: {errors}"
+
+
+# Defense-in-depth: qemu_args() must refuse to emit unsafe values even when
+# validate() was never called (or the field was mutated after validation).
+# These strings are chosen so that if they DID reach the arg list they would
+# inject sibling key=value options into QEMU's comma-separated -drive / -iscsi
+# option syntax.
+
+def test_qemu_args_rejects_injecting_target_iqn():
+    d = _device(targets=[ISCSIDiskTarget(iqn="iqn.2026-06.net.x:a,readonly=on")])
+    with pytest.raises(ValueError, match="target IQN"):
+        d.qemu_args(CTX_Q35)
+
+
+def test_qemu_args_rejects_injecting_initiator_iqn():
+    d = _device(initiator_iqn="iqn.2026-06.net.x:a,password=pw")
+    with pytest.raises(ValueError, match="initiator IQN"):
+        d.qemu_args(CTX_Q35)
+
+
+def test_qemu_args_rejects_non_ip_portal():
+    d = _device(portal_address="evil.example.com,file=/etc/shadow")
+    with pytest.raises(ValueError, match="portal address"):
+        d.qemu_args(CTX_Q35)
+
+
+def test_qemu_args_rejects_field_mutated_after_construction():
+    """Mutating an IQN after construction bypasses validate(); qemu_args()
+    must still refuse to emit unsafe args."""
+    d = _device()
+    d.targets[0].iqn = "iqn.2026-06.net.x:a,readonly=on"
+    with pytest.raises(ValueError, match="target IQN"):
+        d.qemu_args(CTX_Q35)

--- a/truenas_pylibvirt/device/iscsi_disk.py
+++ b/truenas_pylibvirt/device/iscsi_disk.py
@@ -9,7 +9,22 @@ from .base import Device, DeviceXmlContext, QemuArgsContext
 
 
 # RFC 3720 IQN: iqn.YYYY-MM.<reversed-domain>[:<suffix>]
-IQN_RE = re.compile(r'^iqn\.\d{4}-\d{2}\.[a-zA-Z][a-zA-Z0-9\-\.]*(?::[^\s]*)?$')
+#
+# The suffix character set is intentionally restrictive (RFC 3721 naming-string
+# character set: alphanumerics plus '.', '-', ':'). We MUST NOT admit ',', '=',
+# quotes, backslashes, or whitespace because IQNs are interpolated unquoted
+# into QEMU option strings such as
+#     -drive file=iscsi://<portal>/<iqn>/<lun>,if=none,id=...,format=raw,...
+#     -iscsi initiator-name=<iqn>
+# where those characters would terminate the value and inject sibling
+# key=value options into the same argv token (e.g. an IQN of
+# "iqn.2026-06.net.x:a,readonly=on" would flip the drive to read-only, and
+# ",file=/etc/shadow" would redirect the backing file entirely).
+IQN_RE = re.compile(
+    r'^iqn\.\d{4}-\d{2}\.'
+    r'[a-zA-Z][a-zA-Z0-9\-\.]*'
+    r'(?::[A-Za-z0-9._:\-]+)?$'
+)
 
 
 @dataclass
@@ -40,15 +55,31 @@ class ISCSIDiskDevice(Device):
         return []
 
     def qemu_args(self, context: QemuArgsContext) -> list[str]:
+        # Defense-in-depth: re-verify every field that is interpolated into a
+        # QEMU option string before emitting args, even though validate_impl()
+        # already covers the same ground. A caller that bypasses validate()
+        # (or mutates fields after validation) must not be able to inject
+        # sibling QEMU options through commas/equals in an IQN or portal.
+        if not IQN_RE.match(self.initiator_iqn):
+            raise ValueError(f"Unsafe initiator IQN: {self.initiator_iqn!r}")
+        for t in self.targets:
+            if not IQN_RE.match(t.iqn):
+                raise ValueError(f"Unsafe target IQN: {t.iqn!r}")
+        # portal must parse as an IP address; the URI syntax has no room for
+        # anything else and a hostname here would also be an injection vector.
+        try:
+            addr = ipaddress.ip_address(self.portal_address)
+        except ValueError:
+            raise ValueError(
+                f"Unsafe portal address: {self.portal_address!r} "
+                "(must be an IPv4 or IPv6 literal)"
+            )
+
         mt = context.machine_type or ''
         # q35 and aarch64 virt are both PCIe-native (pcie-root); i440fx uses pci.0.
         root_bus = 'pcie.0' if ('q35' in mt or mt.startswith('virt')) else 'pci.0'
         # IPv6 addresses must be bracketed in iSCSI URIs.
-        try:
-            addr = ipaddress.ip_address(self.portal_address)
-            portal = f"[{self.portal_address}]" if isinstance(addr, ipaddress.IPv6Address) else self.portal_address
-        except ValueError:
-            portal = self.portal_address
+        portal = f"[{self.portal_address}]" if isinstance(addr, ipaddress.IPv6Address) else self.portal_address
         controller_id = f"scsi-iscsi-{self.controller_slot:x}"
         args = [
             "-iscsi", f"initiator-name={self.initiator_iqn}",


### PR DESCRIPTION
IQN_RE's suffix pattern was [^\s]*, which admitted commas and '='. IQNs (and the portal address) are interpolated unquoted into QEMU option strings -- `-drive file=iscsi://<portal>/<iqn>/<lun>,if=none, id=...,format=raw,...` and `-iscsi initiator-name=<iqn>` -- where those characters terminate the value and inject sibling key=value options into the same argv token. An IQN of "iqn.2026-06.net.x:a, readonly=on" flips the drive to read-only; ",file=/etc/shadow" redirects the backing file entirely.

Tighten IQN_RE to the RFC 3721 naming-string character set ([A-Za-z0-9._:-]+ after the initial colon). Add defense-in-depth re-validation in qemu_args() for both IQN fields and the portal address (must parse as IP) so a caller that skips validate() or mutates a field after validation still cannot inject options -- qemu_args() raises ValueError instead of emitting.

Tests cover the injection strings via validate() and the mutate-after-validate bypass via qemu_args().