### PR TITLE
NAS-141904 / 27.0.0-BETA.1 / Reconnect dead libvirt connections instead of raising

### DIFF
--- a/tests/libvirtd/test_connection.py
+++ b/tests/libvirtd/test_connection.py
@@ -1,0 +1,128 @@
+"""Tests for Connection's lazy, self-healing `connection` property.
+
+The property must transparently reconnect when the cached connection is dead.
+The tricky part (NAS-109072) is that a dead libvirt connection raises from the
+liveness probes (isAlive()/listAllDomains()) instead of returning a falsy
+value, so the probe must be caught and turned into a reconnect. Reconnects are
+serialized so concurrent callers don't open (and leak) multiple connections.
+"""
+from __future__ import annotations
+
+import threading
+from unittest.mock import Mock
+
+import libvirt
+
+from truenas_pylibvirt.libvirtd.connection import Connection
+
+
+def _make_conn() -> Mock:
+    conn = Mock(name="libvirt_conn")
+    conn.isAlive.return_value = True
+    conn.listAllDomains.return_value = []
+    return conn
+
+
+def test_first_access_opens_registers_and_keepalive():
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+
+    connection = Connection(manager, "qemu:///system")
+    got = connection.connection
+
+    assert got is conn
+    manager.open.assert_called_once_with("qemu:///system")
+    conn.domainEventRegister.assert_called_once()
+    conn.setKeepAlive.assert_called_once_with(5, 3)
+    conn.close.assert_not_called()  # nothing to replace on the first open
+
+
+def test_alive_connection_is_reused():
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+
+    connection = Connection(manager, "uri")
+
+    assert connection.connection is conn
+    assert connection.connection is conn
+    manager.open.assert_called_once()
+
+
+def test_dead_connection_reconnects_when_listalldomains_raises():
+    """The regression: a dead connection whose probe RAISES must reconnect,
+    not propagate the error."""
+    manager = Mock()
+    conn_a, conn_b = _make_conn(), _make_conn()
+    manager.open.side_effect = [conn_a, conn_b]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.listAllDomains.side_effect = libvirt.libvirtError("client socket is closed")
+
+    assert connection.connection is conn_b
+    assert manager.open.call_count == 2
+    conn_a.close.assert_called_once()  # dead connection dropped, not leaked
+    conn_b.domainEventRegister.assert_called_once()
+
+
+def test_dead_connection_reconnects_when_isalive_raises():
+    manager = Mock()
+    conn_a, conn_b = _make_conn(), _make_conn()
+    manager.open.side_effect = [conn_a, conn_b]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.isAlive.side_effect = libvirt.libvirtError("internal error")
+
+    assert connection.connection is conn_b
+    assert manager.open.call_count == 2
+    conn_a.close.assert_called_once()
+
+
+def test_isalive_false_reconnects():
+    manager = Mock()
+    conn_a, conn_b = _make_conn(), _make_conn()
+    manager.open.side_effect = [conn_a, conn_b]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.isAlive.return_value = False
+
+    assert connection.connection is conn_b
+    conn_a.close.assert_called_once()
+
+
+def test_concurrent_access_opens_once():
+    """Under contention the reconnect is serialized: exactly one open, and
+    every caller gets the same connection object."""
+    manager = Mock()
+    # Distinct object per open() so a double-open would be observable.
+    manager.open.side_effect = [_make_conn() for _ in range(16)]
+
+    connection = Connection(manager, "uri")
+
+    n = 8
+    barrier = threading.Barrier(n)
+    results: list = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        barrier.wait()  # maximize contention on the first access
+        conn = connection.connection
+        with results_lock:
+            results.append(conn)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    manager.open.assert_called_once()
+    assert len(results) == n
+    assert all(r is results[0] for r in results)

--- a/truenas_pylibvirt/libvirtd/connection.py
+++ b/truenas_pylibvirt/libvirtd/connection.py
@@ -5,6 +5,7 @@ import enum
 import functools
 import logging
 import os
+import threading
 from typing import Any, Callable, TYPE_CHECKING
 
 import libvirt
@@ -68,22 +69,27 @@ class Connection:
         self.manager = manager
         self.uri = uri
         self._connection = None
+        self._connection_lock = threading.Lock()
         self._domain_event_callbacks: list[DomainEventCallback] = []
 
     @property
     def connection(self) -> Any:
-        # We see isAlive call failed for a user in NAS-109072, it would be better
-        # if we handle this to ensure that system recognises libvirt connection
-        # is no longer active and a new one should be initiated.
-        if (
-            self._connection and
-            self._connection.isAlive() and
-            isinstance(self._connection.listAllDomains(), list)
-        ):
+        # Serialize check+reconnect so concurrent callers don't open (and leak)
+        # multiple connections.
+        with self._connection_lock:
+            if self._connection is not None and self._connection_is_alive(self._connection):
+                return self._connection
+
+            self._open()
             return self._connection
 
-        self._open()
-        return self._connection
+    @staticmethod
+    def _connection_is_alive(connection: Any) -> bool:
+        # NAS-109072: a dead connection raises here instead of returning falsy.
+        try:
+            return bool(connection.isAlive()) and isinstance(connection.listAllDomains(), list)
+        except libvirt.libvirtError:
+            return False
 
     def register_domain_event_callback(self, callback: DomainEventCallback) -> None:
         self._domain_event_callbacks.append(callback)
@@ -143,6 +149,14 @@ class Connection:
         }.get(event, VirDomainEvent.UNKNOWN)
 
     def _open(self) -> None:
+        # Close the connection being replaced so it isn't leaked.
+        if self._connection is not None:
+            old, self._connection = self._connection, None
+            try:
+                old.close()
+            except libvirt.libvirtError:
+                logger.debug("Discarding unusable libvirt connection for %s", self.uri, exc_info=True)
+
         connection = self.manager.open(self.uri)
 
         connection.domainEventRegister(self._libvirt_event_callback, None)


### PR DESCRIPTION
A dead connection makes the isAlive()/listAllDomains() probe raise libvirtError instead of returning falsy (NAS-109072), so Connection.connection propagated the error instead of reconnecting. Catch libvirtError in the probe and reconnect. Lock the check+reconnect so concurrent callers don't open and leak duplicate connections; close the replaced connection in _open().