### PR TITLE
NAS-141907 / 27.0.0-BETA.1 / Harden nsexec argument and namespace-fd handling

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Build native extension
+      run: |
+        apt-get update
+        apt-get install -y --no-install-recommends libcap-dev
+        python3 -c "from setuptools import setup; setup()" build_ext --inplace
+
     - name: Test
       run: |
         PYTHONPATH=. pytest-3 -v --tb=short tests/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,6 +20,10 @@ jobs:
         apt-get update
         apt-get install -y --no-install-recommends libcap-dev
         python3 -c "from setuptools import setup; setup()" build_ext --inplace
+        # Fail here if the build produced nothing, so a broken build is
+        # attributed to this step rather than surfacing as a pytest
+        # collection error in the next one.
+        PYTHONPATH=. python3 -c "import truenas_pylibvirt.nsexec._native"
 
     - name: Test
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .pybuild/
 *.egg-info/
 __pycache__
+# `build_ext --inplace` output (see .github/workflows/unit_tests.yml)
+build/
+*.so

--- a/tests/nsexec/conftest.py
+++ b/tests/nsexec/conftest.py
@@ -1,0 +1,8 @@
+# The nsexec package imports the compiled _native extension at import time, so
+# these tests need it built. On a plain source checkout it isn't, so skip them
+# instead of failing collection; CI builds the extension (see unit_tests.yml).
+collect_ignore_glob = []
+try:
+    import truenas_pylibvirt.nsexec._native  # noqa: F401
+except ImportError:
+    collect_ignore_glob = ["test_*.py"]

--- a/tests/nsexec/conftest.py
+++ b/tests/nsexec/conftest.py
@@ -1,8 +1,0 @@
-# The nsexec package imports the compiled _native extension at import time, so
-# these tests need it built. On a plain source checkout it isn't, so skip them
-# instead of failing collection; CI builds the extension (see unit_tests.yml).
-collect_ignore_glob = []
-try:
-    import truenas_pylibvirt.nsexec._native  # noqa: F401
-except ImportError:
-    collect_ignore_glob = ["test_*.py"]

--- a/tests/nsexec/test_cli.py
+++ b/tests/nsexec/test_cli.py
@@ -1,0 +1,49 @@
+"""Tests for _write_all (partial-write safety) and the -n/interactive
+argument conflict."""
+from __future__ import annotations
+
+import pytest
+
+from truenas_pylibvirt.nsexec import cli
+
+
+def test_write_all_loops_until_drained(monkeypatch):
+    written: list[bytes] = []
+
+    def one_byte_at_a_time(fd, data):
+        written.append(bytes(data[:1]))
+        return 1  # short write
+
+    monkeypatch.setattr(cli.os, "write", one_byte_at_a_time)
+    cli._write_all(7, b"hello")
+
+    assert b"".join(written) == b"hello"
+    assert len(written) == 5  # every byte delivered despite short writes
+
+
+def test_write_all_single_shot(monkeypatch):
+    calls: list[bytes] = []
+
+    def full_write(fd, data):
+        calls.append(bytes(data))
+        return len(data)
+
+    monkeypatch.setattr(cli.os, "write", full_write)
+    cli._write_all(7, b"hi")
+
+    assert calls == [b"hi"]
+
+
+@pytest.mark.parametrize("extra", [["-t"], ["--mode", "interactive"]])
+def test_n_conflicts_with_interactive(monkeypatch, extra):
+    monkeypatch.setattr(cli.os, "geteuid", lambda: 0)
+    with pytest.raises(SystemExit) as ei:
+        cli.main(["ct", "-n", *extra])
+    assert ei.value.code == 2
+
+
+def test_t_and_T_still_conflict(monkeypatch):
+    monkeypatch.setattr(cli.os, "geteuid", lambda: 0)
+    with pytest.raises(SystemExit) as ei:
+        cli.main(["ct", "-t", "-T"])
+    assert ei.value.code == 2

--- a/tests/nsexec/test_cli.py
+++ b/tests/nsexec/test_cli.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import pytest
 
+# Importing this pulls in the compiled _native extension. If it isn't built,
+# collection fails here and the run goes red -- deliberately. Build it with
+# `python3 -c "from setuptools import setup; setup()" build_ext --inplace`.
 from truenas_pylibvirt.nsexec import cli
 
 
@@ -21,29 +24,22 @@ def test_write_all_loops_until_drained(monkeypatch):
     assert len(written) == 5  # every byte delivered despite short writes
 
 
-def test_write_all_single_shot(monkeypatch):
-    calls: list[bytes] = []
-
-    def full_write(fd, data):
-        calls.append(bytes(data))
-        return len(data)
-
-    monkeypatch.setattr(cli.os, "write", full_write)
-    cli._write_all(7, b"hi")
-
-    assert calls == [b"hi"]
-
-
+# Every _die() in main() exits 2 — including the libvirt-connect failure a
+# few lines below these checks, and argparse's own usage errors. So the
+# argument-conflict tests must assert on the message; asserting the exit
+# code alone passes even with the check deleted outright.
 @pytest.mark.parametrize("extra", [["-t"], ["--mode", "interactive"]])
-def test_n_conflicts_with_interactive(monkeypatch, extra):
+def test_n_conflicts_with_interactive(monkeypatch, capsys, extra):
     monkeypatch.setattr(cli.os, "geteuid", lambda: 0)
     with pytest.raises(SystemExit) as ei:
         cli.main(["ct", "-n", *extra])
     assert ei.value.code == 2
+    assert "-n cannot be combined with interactive mode" in capsys.readouterr().err
 
 
-def test_t_and_T_still_conflict(monkeypatch):
+def test_t_and_T_still_conflict(monkeypatch, capsys):
     monkeypatch.setattr(cli.os, "geteuid", lambda: 0)
     with pytest.raises(SystemExit) as ei:
         cli.main(["ct", "-t", "-T"])
     assert ei.value.code == 2
+    assert "-t and -T are mutually exclusive" in capsys.readouterr().err

--- a/tests/nsexec/test_main.py
+++ b/tests/nsexec/test_main.py
@@ -1,0 +1,40 @@
+"""Tests for the __main__ wire entry point's argument validation (fail-closed
+on a malformed idmap flag rather than defaulting to privileged)."""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+import truenas_pylibvirt.nsexec.__main__ as entry
+
+
+def test_too_few_args_exits(monkeypatch):
+    monkeypatch.setattr(entry.sys, "argv", ["prog", "uri", "uuid", "drops"])
+    with pytest.raises(SystemExit, match="usage"):
+        entry.main()
+
+
+def test_bad_idmap_flag_exits(monkeypatch):
+    monkeypatch.setattr(entry.sys, "argv", ["prog", "uri", "uuid", "drops", "caps", "yes"])
+    with pytest.raises(SystemExit, match="idmap flag"):
+        entry.main()
+
+
+def test_valid_args_forward_to_runner(monkeypatch):
+    monkeypatch.setattr(
+        entry.sys, "argv",
+        ["prog", "uri", "uu", "cap_a,cap_b", "cap_x+ep", "1", "/bin/sh", "-c", "id"],
+    )
+    dom = Mock()
+    conn = Mock()
+    conn.lookupByUUIDString.return_value = dom
+    monkeypatch.setattr(entry.libvirt, "open", Mock(return_value=conn))
+    run = Mock(return_value=0)
+    monkeypatch.setattr(entry, "run_in_container", run)
+
+    with pytest.raises(SystemExit) as ei:
+        entry.main()
+
+    assert ei.value.code == 0
+    run.assert_called_once_with(dom, ["cap_a", "cap_b"], "cap_x+ep", True, ["/bin/sh", "-c", "id"])

--- a/tests/nsexec/test_native.py
+++ b/tests/nsexec/test_native.py
@@ -6,10 +6,7 @@ This exercises the waitpid loop and exit-status translation.
 """
 from __future__ import annotations
 
-import contextlib
-import os
 import signal
-import time
 
 import pytest
 
@@ -38,26 +35,25 @@ def test_empty_argv_rejected():
         enter_and_exec(-1, [], [], "", [])
 
 
-def test_pending_signal_interrupts_wait():
-    """A Python signal handler firing while enter_and_exec is blocked in
-    waitpid must run and its exception propagate *promptly*, not be swallowed
-    by the EINTR retry until the child exits on its own. The child runs for 1s;
-    the alarm fires at 0.1s, so a correct wait returns well under 0.5s while a
-    blind retry only returns after the full sleep."""
-    def _boom(_signum, _frame):
-        raise KeyboardInterrupt
+def test_benign_signal_does_not_abort_wait():
+    """A signal whose Python handler returns normally must not abort the wait.
 
-    old = signal.signal(signal.SIGALRM, _boom)
+    waitpid takes the EINTR, PyErr_CheckSignals runs the handler, and the
+    retry picks the child's real exit status back up. Without the retry this
+    raised OSError(EINTR) and the caller lost the status entirely -- which is
+    the bug the EINTR loop fixes.
+
+    Note the handler here deliberately does *not* raise: a raising handler
+    (KeyboardInterrupt) already propagated correctly before the fix, because
+    the eval loop runs pending handlers while the OSError unwinds. Only the
+    benign case distinguishes the two implementations.
+    """
+    fired = []
+    old = signal.signal(signal.SIGALRM, lambda _signum, _frame: fired.append(1))
     try:
         signal.setitimer(signal.ITIMER_REAL, 0.1)
-        start = time.monotonic()
-        with pytest.raises(KeyboardInterrupt):
-            enter_and_exec(-1, [], [], "", ["/bin/sh", "-c", "sleep 1"])
-        elapsed = time.monotonic() - start
-        assert elapsed < 0.5, f"wait was not interrupted promptly ({elapsed:.2f}s)"
+        assert enter_and_exec(-1, [], [], "", ["/bin/sh", "-c", "sleep 0.4; exit 7"]) == 7
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGALRM, old)
-        # Reap the in-container child the interrupted wait left running.
-        with contextlib.suppress(ChildProcessError):
-            os.waitpid(-1, 0)
+    assert fired, "SIGALRM never landed; the test did not exercise the EINTR path"

--- a/tests/nsexec/test_native.py
+++ b/tests/nsexec/test_native.py
@@ -1,0 +1,63 @@
+"""Tests for enter_and_exec's fork/exec/waitpid path.
+
+Run with user_fd=-1 and no drops/caps, so no namespace or privilege state of
+the test process is touched -- only a child is forked, exec'd, and reaped.
+This exercises the waitpid loop and exit-status translation.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import time
+
+import pytest
+
+from truenas_pylibvirt.nsexec._native import enter_and_exec
+
+
+def test_exit_zero():
+    assert enter_and_exec(-1, [], [], "", ["/bin/true"]) == 0
+
+
+def test_exit_nonzero():
+    assert enter_and_exec(-1, [], [], "", ["/bin/false"]) == 1
+
+
+def test_command_not_found():
+    assert enter_and_exec(-1, [], [], "", ["/nonexistent-command-xyz"]) == 127
+
+
+def test_terminated_by_signal():
+    # Child SIGKILLs itself -> 128 + 9.
+    assert enter_and_exec(-1, [], [], "", ["/bin/sh", "-c", "kill -9 $$"]) == 137
+
+
+def test_empty_argv_rejected():
+    with pytest.raises(ValueError, match="argv must not be empty"):
+        enter_and_exec(-1, [], [], "", [])
+
+
+def test_pending_signal_interrupts_wait():
+    """A Python signal handler firing while enter_and_exec is blocked in
+    waitpid must run and its exception propagate *promptly*, not be swallowed
+    by the EINTR retry until the child exits on its own. The child runs for 1s;
+    the alarm fires at 0.1s, so a correct wait returns well under 0.5s while a
+    blind retry only returns after the full sleep."""
+    def _boom(_signum, _frame):
+        raise KeyboardInterrupt
+
+    old = signal.signal(signal.SIGALRM, _boom)
+    try:
+        signal.setitimer(signal.ITIMER_REAL, 0.1)
+        start = time.monotonic()
+        with pytest.raises(KeyboardInterrupt):
+            enter_and_exec(-1, [], [], "", ["/bin/sh", "-c", "sleep 1"])
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5, f"wait was not interrupted promptly ({elapsed:.2f}s)"
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old)
+        # Reap the in-container child the interrupted wait left running.
+        with contextlib.suppress(ChildProcessError):
+            os.waitpid(-1, 0)

--- a/tests/nsexec/test_runner.py
+++ b/tests/nsexec/test_runner.py
@@ -2,6 +2,7 @@
 namespace-fd validation), which must fail cleanly and not leak fds."""
 from __future__ import annotations
 
+import os
 from unittest.mock import Mock
 
 import pytest
@@ -16,14 +17,36 @@ def _dom(domain_id: int = 1234, name: str = "ct") -> Mock:
     return dom
 
 
-def test_not_running_domain_raises_before_opening_namespaces(monkeypatch):
+def test_split_user_fd_classifies_real_fds():
+    """The user-ns fd is found by readlink'ing /proc/self/fd/<n>, not by its
+    position in the list libvirt returns (which is undocumented)."""
+    fds = [
+        os.open("/proc/self/ns/uts", os.O_RDONLY),
+        os.open("/proc/self/ns/user", os.O_RDONLY),
+        os.open("/proc/self/ns/ipc", os.O_RDONLY),
+    ]
+    try:
+        user_fd, other_fds = runner._split_user_fd(fds)
+        assert user_fd == fds[1]
+        assert other_fds == [fds[0], fds[2]]
+    finally:
+        for fd in fds:
+            os.close(fd)
+
+
+def test_not_running_domain_raises_before_touching_the_container(monkeypatch):
+    move = Mock()
     lxc = Mock()
+    monkeypatch.setattr(runner, "_move_into_cgroup", move)
     monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", lxc)
-    monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
 
     with pytest.raises(RuntimeError, match="not running"):
         runner.run_in_container(_dom(domain_id=-1), [], "", True, ["/bin/sh"])
 
+    # The bug being guarded: ID() == -1 fell through to _move_into_cgroup(-1),
+    # which opened /proc/-1/cgroup. Asserting only on lxcOpenNamespace would
+    # still pass with the check moved back below the cgroup join.
+    move.assert_not_called()
     lxc.assert_not_called()
 
 
@@ -43,17 +66,21 @@ def test_idmap_without_user_fd_raises_and_closes_all_fds(monkeypatch):
     enter.assert_not_called()
 
 
-def test_no_namespace_fds_raises(monkeypatch):
+def test_only_user_fd_returned_raises_and_closes_it(monkeypatch):
+    # A reachable shape: libvirt hands back a user-ns fd and nothing else, so
+    # _split_user_fd leaves other_fds empty and there is nothing to setns into.
+    closed: list[int] = []
     monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
     monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", Mock(return_value=[5]))
-    monkeypatch.setattr(runner, "_split_user_fd", Mock(return_value=(-1, [])))
-    monkeypatch.setattr(runner.os, "close", Mock())
+    monkeypatch.setattr(runner, "_split_user_fd", Mock(return_value=(5, [])))
+    monkeypatch.setattr(runner.os, "close", closed.append)
     enter = Mock()
     monkeypatch.setattr(runner, "enter_and_exec", enter)
 
     with pytest.raises(RuntimeError, match="no container namespace"):
         runner.run_in_container(_dom(), [], "", False, ["/bin/sh"])
 
+    assert closed == [5]
     enter.assert_not_called()
 
 

--- a/tests/nsexec/test_runner.py
+++ b/tests/nsexec/test_runner.py
@@ -1,0 +1,85 @@
+"""Tests for run_in_container's pre-flight checks (not-running domain and the
+namespace-fd validation), which must fail cleanly and not leak fds."""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+import truenas_pylibvirt.nsexec._runner as runner
+
+
+def _dom(domain_id: int = 1234, name: str = "ct") -> Mock:
+    dom = Mock()
+    dom.ID.return_value = domain_id
+    dom.name.return_value = name
+    return dom
+
+
+def test_not_running_domain_raises_before_opening_namespaces(monkeypatch):
+    lxc = Mock()
+    monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", lxc)
+    monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
+
+    with pytest.raises(RuntimeError, match="not running"):
+        runner.run_in_container(_dom(domain_id=-1), [], "", True, ["/bin/sh"])
+
+    lxc.assert_not_called()
+
+
+def test_idmap_without_user_fd_raises_and_closes_all_fds(monkeypatch):
+    closed: list[int] = []
+    monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
+    monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", Mock(return_value=[7, 8, 9]))
+    monkeypatch.setattr(runner, "_split_user_fd", Mock(return_value=(-1, [8, 9])))
+    monkeypatch.setattr(runner.os, "close", closed.append)
+    enter = Mock()
+    monkeypatch.setattr(runner, "enter_and_exec", enter)
+
+    with pytest.raises(RuntimeError, match="user namespace"):
+        runner.run_in_container(_dom(), [], "", True, ["/bin/sh"])
+
+    assert sorted(closed) == [7, 8, 9]  # every fd libvirt returned is closed
+    enter.assert_not_called()
+
+
+def test_no_namespace_fds_raises(monkeypatch):
+    monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
+    monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", Mock(return_value=[5]))
+    monkeypatch.setattr(runner, "_split_user_fd", Mock(return_value=(-1, [])))
+    monkeypatch.setattr(runner.os, "close", Mock())
+    enter = Mock()
+    monkeypatch.setattr(runner, "enter_and_exec", enter)
+
+    with pytest.raises(RuntimeError, match="no container namespace"):
+        runner.run_in_container(_dom(), [], "", False, ["/bin/sh"])
+
+    enter.assert_not_called()
+
+
+def test_happy_path_idmap_forwards_fds(monkeypatch):
+    monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
+    monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", Mock(return_value=[3, 4, 5]))
+    monkeypatch.setattr(runner, "_split_user_fd", Mock(return_value=(3, [4, 5])))
+    enter = Mock(return_value=42)
+    monkeypatch.setattr(runner, "enter_and_exec", enter)
+
+    rc = runner.run_in_container(_dom(), ["cap_lease"], "cap_net_admin+ep", True, ["/bin/sh"])
+
+    assert rc == 42
+    enter.assert_called_once_with(3, [4, 5], ["cap_lease"], "cap_net_admin+ep", ["/bin/sh"])
+
+
+def test_privileged_closes_stray_user_fd(monkeypatch):
+    closed: list[int] = []
+    monkeypatch.setattr(runner, "_move_into_cgroup", Mock())
+    monkeypatch.setattr(runner.libvirt_lxc, "lxcOpenNamespace", Mock(return_value=[3, 4, 5]))
+    monkeypatch.setattr(runner, "_split_user_fd", Mock(return_value=(3, [4, 5])))
+    monkeypatch.setattr(runner.os, "close", closed.append)
+    enter = Mock(return_value=0)
+    monkeypatch.setattr(runner, "enter_and_exec", enter)
+
+    runner.run_in_container(_dom(), [], "", False, ["/bin/sh"])  # has_idmap=False
+
+    assert closed == [3]  # stray user-ns fd dropped for a privileged container
+    enter.assert_called_once_with(-1, [4, 5], [], "", ["/bin/sh"])

--- a/truenas_pylibvirt/nsexec/__main__.py
+++ b/truenas_pylibvirt/nsexec/__main__.py
@@ -18,11 +18,15 @@ from ._runner import run_in_container
 
 
 def main() -> None:
-    uri = sys.argv[1]
-    uuid = sys.argv[2]
-    drop_csv = sys.argv[3]
-    caps_text = sys.argv[4]
-    has_idmap = sys.argv[5] == "1"
+    if len(sys.argv) < 6:
+        raise SystemExit(
+            "usage: python3 -m truenas_pylibvirt.nsexec "
+            "<uri> <uuid> <drop_csv> <caps_text> <0|1> [argv...]"
+        )
+    uri, uuid, drop_csv, caps_text, idmap_flag = sys.argv[1:6]
+    if idmap_flag not in ("0", "1"):
+        raise SystemExit(f"idmap flag must be '0' or '1', got {idmap_flag!r}")
+    has_idmap = idmap_flag == "1"
     argv = sys.argv[6:]
 
     conn = libvirt.open(uri)

--- a/truenas_pylibvirt/nsexec/_native.c
+++ b/truenas_pylibvirt/nsexec/_native.c
@@ -465,9 +465,21 @@ py_enter_and_exec(PyObject *self, PyObject *args)
     PyMem_RawFree(drop_nums);
     PyMem_RawFree(other_fd);
 
+    /* Retry on EINTR, but run pending Python signal handlers between tries
+     * (mirrors CPython's os.waitpid): a handler that raises — e.g. the
+     * default SIGINT -> KeyboardInterrupt — must interrupt the wait rather
+     * than be swallowed by a blind retry. async_err distinguishes "handler
+     * raised" (propagate it) from "waitpid failed" (raise OSError). */
     int status;
-    if (waitpid(child, &status, 0) < 0)
-        return PyErr_SetFromErrno(PyExc_OSError);
+    pid_t waited;
+    int async_err = 0;
+    do {
+        Py_BEGIN_ALLOW_THREADS
+        waited = waitpid(child, &status, 0);
+        Py_END_ALLOW_THREADS
+    } while (waited < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
+    if (waited < 0)
+        return async_err ? NULL : PyErr_SetFromErrno(PyExc_OSError);
     if (WIFEXITED(status))
         return PyLong_FromLong(WEXITSTATUS(status));
     if (WIFSIGNALED(status))

--- a/truenas_pylibvirt/nsexec/_runner.py
+++ b/truenas_pylibvirt/nsexec/_runner.py
@@ -10,6 +10,7 @@ therefore unsafe to call from a multi-threaded daemon.
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING
 
@@ -87,10 +88,23 @@ def run_in_container(
     :returns: exit status of the in-container process (128+signo if
         terminated by signal)
     """
-    _move_into_cgroup(dom.ID())
+    init_pid = dom.ID()
+    if init_pid < 0:
+        raise RuntimeError(f"container {dom.name()!r} is not running")
+    _move_into_cgroup(init_pid)
 
     fds = libvirt_lxc.lxcOpenNamespace(dom, 0)
-    user_fd, other_fds = _split_user_fd(fds)
+    try:
+        user_fd, other_fds = _split_user_fd(fds)
+        if not other_fds:
+            raise RuntimeError("libvirt returned no container namespace fds")
+        if has_idmap and user_fd < 0:
+            raise RuntimeError("idmapped container is missing its user namespace fd")
+    except BaseException:
+        for fd in fds:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        raise
 
     # Privileged container (no idmap) — skip the user-ns setns so the
     # process keeps host credentials. Close the fd defensively if

--- a/truenas_pylibvirt/nsexec/cli.py
+++ b/truenas_pylibvirt/nsexec/cli.py
@@ -203,6 +203,12 @@ def _decide_interactive(args: argparse.Namespace) -> bool:
     return os.isatty(0) and os.isatty(1)
 
 
+def _write_all(fd: int, data: bytes) -> None:
+    """os.write may write fewer bytes than requested; loop until all are out."""
+    while data:
+        data = data[os.write(fd, data):]
+
+
 def _relay(stdin_fd: int, master_fd: int) -> None:
     """Ferry bytes between host stdin/stdout and the PTY master.
 
@@ -239,7 +245,7 @@ def _relay(stdin_fd: int, master_fd: int) -> None:
                 raise
             if not data:
                 return
-            os.write(1, data)
+            _write_all(1, data)
         if stdin_fd in ready:
             try:
                 data = os.read(stdin_fd, 4096)
@@ -254,7 +260,7 @@ def _relay(stdin_fd: int, master_fd: int) -> None:
                     os.write(master_fd, veof)
                 read_fds = [master_fd]
                 continue
-            os.write(master_fd, data)
+            _write_all(master_fd, data)
 
 
 def _run_interactive(
@@ -509,6 +515,8 @@ def main(argv: list[str] | None = None) -> None:
         _die("-t and -T are mutually exclusive")
     if args.mode != "auto" and (args.force_interactive or args.force_non_interactive):
         _die("--mode is mutually exclusive with -t/-T")
+    if args.disable_stdin and (args.force_interactive or args.mode == "interactive"):
+        _die("-n cannot be combined with interactive mode (-t / --mode interactive)")
 
     command = list(args.command)
     if command and command[0] == "--":


### PR DESCRIPTION
`run_in_container`: raise a clear error when the domain isn't running (dom.ID() < 0) instead of opening /proc/-1/cgroup, and validate that libvirt returned the container namespace fds (and a user-ns fd for idmapped containers) before entering; close the fds on the error path.

`__main__:` reject a missing/invalid idmap flag instead of treating any non-"1" value as privileged.

`cli`: loop os.write in the PTY relay so a short write doesn't drop bytes; reject -n combined with interactive mode instead of silently ignoring -t.

`_native`: retry waitpid on EINTR.