### PR TITLE
NAS-141911 / 26.0.0-RC.1 / Don't start the spice-html5 proxy when web access is disabled (by anodos325)

### DIFF
--- a/tests/device/test_display.py
+++ b/tests/device/test_display.py
@@ -1,6 +1,8 @@
 """Tests for Display device XML generation."""
 from __future__ import annotations
 
+from unittest.mock import Mock, patch
+
 import pytest
 from xml.etree import ElementTree as ET
 
@@ -69,3 +71,47 @@ def test_display_identity(mock_device_delegate):
     # Display devices use bind:port for identity
     identity = device.identity()
     assert identity == "0.0.0.0:5912"
+
+
+def _display(mock_device_delegate, *, web, type_=DisplayDeviceType.SPICE):
+    return DisplayDevice(
+        type_=type_,
+        resolution="1024x768",
+        port=5912,
+        web_port=5913,
+        bind="0.0.0.0",
+        password="secret",
+        web=web,
+        wait=False,
+        device_delegate=mock_device_delegate,
+    )
+
+
+def test_run_starts_websockify_when_web_enabled(mock_device_delegate):
+    device = _display(mock_device_delegate, web=True)
+    with patch("truenas_pylibvirt.device.display.subprocess.Popen") as popen:
+        popen.return_value = Mock()
+        with device.run(Mock(), "uuid"):
+            pass
+    popen.assert_called_once()
+    argv = popen.call_args.args[0]
+    assert argv[0] == "websockify"
+    assert "0.0.0.0:5912" in argv  # server_addr (bind:port)
+    assert ":5913" in argv         # web_bind (:web_port)
+
+
+def test_run_skips_websockify_when_web_disabled(mock_device_delegate):
+    # Regression: web=False must not start the browser-facing proxy.
+    device = _display(mock_device_delegate, web=False)
+    with patch("truenas_pylibvirt.device.display.subprocess.Popen") as popen:
+        with device.run(Mock(), "uuid"):
+            pass
+    popen.assert_not_called()
+
+
+def test_run_skips_websockify_for_vnc(mock_device_delegate):
+    device = _display(mock_device_delegate, web=False, type_=DisplayDeviceType.VNC)
+    with patch("truenas_pylibvirt.device.display.subprocess.Popen") as popen:
+        with device.run(Mock(), "uuid"):
+            pass
+    popen.assert_not_called()

--- a/truenas_pylibvirt/device/display.py
+++ b/truenas_pylibvirt/device/display.py
@@ -84,7 +84,9 @@ class DisplayDevice(Device):
     @contextmanager
     def run(self, connection: Connection, domain_uuid: str) -> Generator[None, None, None]:
         process = None
-        if self.type_ == DisplayDeviceType.SPICE:
+        # web=False disables browser-based access, so the spice-html5 websockify
+        # proxy must not be started (validate_impl already forbids web for VNC).
+        if self.type_ == DisplayDeviceType.SPICE and self.web:
             web_bind = f":{self.web_port}" if self.bind == "0.0.0.0" else f"{self.bind}:{self.web_port}"
             server_addr = f"{self.bind}:{self.port}"
             process = subprocess.Popen(


### PR DESCRIPTION
DisplayDevice.run() started the websockify proxy for every SPICE display, checking only type, not the web flag. A SPICE display with web=False (documented "disable web-based display access") still got a browser-reachable proxy on web_port. Gate the spawn on self.web too.

Original PR: https://github.com/truenas/truenas_pylibvirt/pull/76
