### PR TITLE
NAS-141953 / 27.0.0-BETA.1 / Deregister domain events before closing libvirt connections

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ghcr.io/truenas/middleware:master
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
+# A worker thread dying is reported as a warning, so a test that only asserts on the
+# main thread passes green while most of its workers never ran.
+filterwarnings = ["error::pytest.PytestUnhandledThreadExceptionWarning"]
 
 [tool.mypy]
 strict = true

--- a/tests/libvirtd/test_connection.py
+++ b/tests/libvirtd/test_connection.py
@@ -5,6 +5,10 @@ The tricky part (NAS-109072) is that a dead libvirt connection raises from the
 liveness probes (isAlive()/listAllDomains()) instead of returning a falsy
 value, so the probe must be caught and turned into a reconnect. Reconnects are
 serialized so concurrent callers don't open (and leak) multiple connections.
+
+Handles that are dropped -- replaced by a reconnect, abandoned because post-open
+setup failed, or closed outright -- must be deregistered as well as closed, since
+a registered event callback keeps the connection alive on its own.
 """
 from __future__ import annotations
 
@@ -12,8 +16,14 @@ import threading
 from unittest.mock import Mock
 
 import libvirt
+import pytest
 
+from truenas_pylibvirt.error import Error
 from truenas_pylibvirt.libvirtd.connection import Connection
+
+
+def _call_names(conn: Mock) -> list[str]:
+    return [name for name, _, _ in conn.mock_calls]
 
 
 def _make_conn() -> Mock:
@@ -95,6 +105,164 @@ def test_isalive_false_reconnects():
 
     assert connection.connection is conn_b
     conn_a.close.assert_called_once()
+
+
+def test_replaced_connection_is_deregistered_before_being_closed():
+    """Closing alone doesn't release a handle that still has an event callback
+    registered, so the reconnect path must deregister first."""
+    manager = Mock()
+    conn_a, conn_b = _make_conn(), _make_conn()
+    manager.open.side_effect = [conn_a, conn_b]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.isAlive.return_value = False
+    assert connection.connection is conn_b
+
+    conn_a.domainEventDeregister.assert_called_once()
+    conn_a.close.assert_called_once()
+    names = _call_names(conn_a)
+    assert names.index("domainEventDeregister") < names.index("close")
+
+
+@pytest.mark.parametrize("error", [libvirt.libvirtError("client socket is closed"), KeyError("callback")])
+def test_replaced_connection_is_closed_even_when_deregistering_fails(error):
+    """Deregistering a handle whose socket is already gone fails, and libvirt raises
+    `KeyError` for a callback it no longer knows about. Neither may stop the close: a
+    handle that is deregistered but left open is the leak this is meant to prevent."""
+    manager = Mock()
+    conn_a, conn_b = _make_conn(), _make_conn()
+    manager.open.side_effect = [conn_a, conn_b]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.domainEventDeregister.side_effect = error
+    conn_a.isAlive.return_value = False
+
+    assert connection.connection is conn_b
+    conn_a.close.assert_called_once()
+
+
+def test_event_register_failure_discards_handle_and_propagates():
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+    conn.domainEventRegister.side_effect = libvirt.libvirtError("register failed")
+
+    connection = Connection(manager, "uri")
+
+    with pytest.raises(libvirt.libvirtError) as exc:
+        connection.connection
+
+    assert exc.value is conn.domainEventRegister.side_effect
+    conn.domainEventDeregister.assert_called_once()
+    conn.close.assert_called_once()
+    assert connection._connection is None
+
+
+def test_keepalive_failure_discards_handle_and_propagates():
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+    conn.setKeepAlive.side_effect = libvirt.libvirtError("keepalive failed")
+
+    connection = Connection(manager, "uri")
+
+    with pytest.raises(libvirt.libvirtError) as exc:
+        connection.connection
+
+    assert exc.value is conn.setKeepAlive.side_effect
+    conn.domainEventDeregister.assert_called_once()
+    conn.close.assert_called_once()
+    assert connection._connection is None
+
+
+def test_setup_failure_propagates_original_error_when_discard_fails():
+    """A failure while cleaning up must not mask the error that caused it."""
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+    conn.setKeepAlive.side_effect = libvirt.libvirtError("keepalive failed")
+    conn.close.side_effect = libvirt.libvirtError("close failed")
+
+    connection = Connection(manager, "uri")
+
+    with pytest.raises(libvirt.libvirtError) as exc:
+        connection.connection
+
+    assert exc.value is conn.setKeepAlive.side_effect
+
+
+def test_close_of_unopened_connection_does_not_open_one():
+    manager = Mock()
+
+    connection = Connection(manager, "uri")
+    connection._close()
+
+    manager.open.assert_not_called()
+
+
+def test_close_deregisters_and_clears_the_handle():
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn
+
+    connection._close()
+
+    conn.domainEventDeregister.assert_called_once()
+    conn.close.assert_called_once()
+    assert connection._connection is None
+    manager.open.assert_called_once()  # never reopened just to be closed
+
+
+def test_close_reports_a_handle_it_could_not_close():
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+    conn.close.side_effect = libvirt.libvirtError("close failed")
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn
+
+    with pytest.raises(Error):
+        connection._close()
+
+    # The handle is unusable once close() has failed, so it must not stay installed.
+    assert connection._connection is None
+
+
+def test_concurrent_close_closes_once():
+    """Only the caller that claims the handle closes it; the rest see it already gone.
+
+    This exercises contention rather than proving the swap is atomic -- under the GIL a
+    thread switch between reading and clearing `_connection` is not reachable from a test.
+    """
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn
+
+    n = 8
+    barrier = threading.Barrier(n)
+
+    def worker() -> None:
+        barrier.wait()
+        connection._close()
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    conn.close.assert_called_once()
 
 
 def test_concurrent_access_opens_once():

--- a/tests/libvirtd/test_connection.py
+++ b/tests/libvirtd/test_connection.py
@@ -7,8 +7,15 @@ value, so the probe must be caught and turned into a reconnect. Reconnects are
 serialized so concurrent callers don't open (and leak) multiple connections.
 
 Handles that are dropped -- replaced by a reconnect, abandoned because post-open
-setup failed, or closed outright -- must be deregistered as well as closed, since
-a registered event callback keeps the connection alive on its own.
+setup failed, or closed outright -- must be deregistered, since a registered event
+callback keeps the connection alive on its own. The handle being replaced is only
+deregistered: another thread may still be inside an RPC on it, and closing would
+free it underneath that thread.
+
+The registration id of the first callback on a fresh handle is genuinely `0`, so
+these mocks return `0` -- with a truthy id the suite cannot see the difference
+between `if callback_id is not None` and `if callback_id`, and the latter silently
+skips the deregister that the whole file exists to pin.
 """
 from __future__ import annotations
 
@@ -26,10 +33,11 @@ def _call_names(conn: Mock) -> list[str]:
     return [name for name, _, _ in conn.mock_calls]
 
 
-def _make_conn() -> Mock:
+def _make_conn(callback_id: int = 0) -> Mock:
     conn = Mock(name="libvirt_conn")
     conn.isAlive.return_value = True
     conn.listAllDomains.return_value = []
+    conn.domainEventRegisterAny.return_value = callback_id
     return conn
 
 
@@ -43,7 +51,9 @@ def test_first_access_opens_registers_and_keepalive():
 
     assert got is conn
     manager.open.assert_called_once_with("qemu:///system")
-    conn.domainEventRegister.assert_called_once()
+    conn.domainEventRegisterAny.assert_called_once_with(
+        None, libvirt.VIR_DOMAIN_EVENT_ID_LIFECYCLE, connection._libvirt_event_callback, None
+    )
     conn.setKeepAlive.assert_called_once_with(5, 3)
     conn.close.assert_not_called()  # nothing to replace on the first open
 
@@ -74,8 +84,8 @@ def test_dead_connection_reconnects_when_listalldomains_raises():
 
     assert connection.connection is conn_b
     assert manager.open.call_count == 2
-    conn_a.close.assert_called_once()  # dead connection dropped, not leaked
-    conn_b.domainEventRegister.assert_called_once()
+    conn_a.domainEventDeregisterAny.assert_called_once_with(0)  # dead connection released, not leaked
+    conn_b.domainEventRegisterAny.assert_called_once()
 
 
 def test_dead_connection_reconnects_when_isalive_raises():
@@ -90,7 +100,7 @@ def test_dead_connection_reconnects_when_isalive_raises():
 
     assert connection.connection is conn_b
     assert manager.open.call_count == 2
-    conn_a.close.assert_called_once()
+    conn_a.domainEventDeregisterAny.assert_called_once_with(0)
 
 
 def test_isalive_false_reconnects():
@@ -104,12 +114,12 @@ def test_isalive_false_reconnects():
     conn_a.isAlive.return_value = False
 
     assert connection.connection is conn_b
-    conn_a.close.assert_called_once()
+    conn_a.domainEventDeregisterAny.assert_called_once_with(0)
 
 
-def test_replaced_connection_is_deregistered_before_being_closed():
-    """Closing alone doesn't release a handle that still has an event callback
-    registered, so the reconnect path must deregister first."""
+def test_replaced_connection_is_deregistered_but_not_closed():
+    """Deregistering is what releases the handle; closing it would free it under any
+    thread still inside an RPC on it, since the property hands out the raw handle."""
     manager = Mock()
     conn_a, conn_b = _make_conn(), _make_conn()
     manager.open.side_effect = [conn_a, conn_b]
@@ -120,17 +130,32 @@ def test_replaced_connection_is_deregistered_before_being_closed():
     conn_a.isAlive.return_value = False
     assert connection.connection is conn_b
 
-    conn_a.domainEventDeregister.assert_called_once()
-    conn_a.close.assert_called_once()
-    names = _call_names(conn_a)
-    assert names.index("domainEventDeregister") < names.index("close")
+    conn_a.domainEventDeregisterAny.assert_called_once_with(0)
+    conn_a.close.assert_not_called()
 
 
-@pytest.mark.parametrize("error", [libvirt.libvirtError("client socket is closed"), KeyError("callback")])
-def test_replaced_connection_is_closed_even_when_deregistering_fails(error):
-    """Deregistering a handle whose socket is already gone fails, and libvirt raises
-    `KeyError` for a callback it no longer knows about. Neither may stop the close: a
-    handle that is deregistered but left open is the leak this is meant to prevent."""
+def test_registration_id_travels_with_its_own_handle():
+    """Each handle is deregistered with the id it was registered with, not with
+    whatever the current handle happens to hold."""
+    manager = Mock()
+    conn_a, conn_b = _make_conn(callback_id=0), _make_conn(callback_id=7)
+    manager.open.side_effect = [conn_a, conn_b]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.isAlive.return_value = False
+    assert connection.connection is conn_b
+
+    conn_a.domainEventDeregisterAny.assert_called_once_with(0)
+    connection._close()
+    conn_b.domainEventDeregisterAny.assert_called_once_with(7)
+
+
+@pytest.mark.parametrize("error", [libvirt.libvirtError("client socket is closed"), RuntimeError("dispatching")])
+def test_reconnect_proceeds_when_deregistering_the_replaced_handle_fails(error):
+    """Deregistering a handle whose socket is already gone fails. That must not abort
+    the reconnect, which is the only thing that restores a working connection."""
     manager = Mock()
     conn_a, conn_b = _make_conn(), _make_conn()
     manager.open.side_effect = [conn_a, conn_b]
@@ -138,31 +163,52 @@ def test_replaced_connection_is_closed_even_when_deregistering_fails(error):
     connection = Connection(manager, "uri")
     assert connection.connection is conn_a
 
-    conn_a.domainEventDeregister.side_effect = error
+    conn_a.domainEventDeregisterAny.side_effect = error
     conn_a.isAlive.return_value = False
 
     assert connection.connection is conn_b
-    conn_a.close.assert_called_once()
+
+
+def test_failed_reopen_leaves_no_handle_installed():
+    """A reconnect that cannot open must not leave the discarded handle installed,
+    or the next access would probe a handle that has already been given back."""
+    manager = Mock()
+    conn_a = _make_conn()
+    manager.open.side_effect = [conn_a, libvirt.libvirtError("connect failed")]
+
+    connection = Connection(manager, "uri")
+    assert connection.connection is conn_a
+
+    conn_a.isAlive.return_value = False
+
+    with pytest.raises(libvirt.libvirtError):
+        connection.connection
+
+    assert connection._connection is None
+    assert connection._callback_id is None
 
 
 def test_event_register_failure_discards_handle_and_propagates():
     manager = Mock()
     conn = _make_conn()
     manager.open.return_value = conn
-    conn.domainEventRegister.side_effect = libvirt.libvirtError("register failed")
+    conn.domainEventRegisterAny.side_effect = libvirt.libvirtError("register failed")
 
     connection = Connection(manager, "uri")
 
     with pytest.raises(libvirt.libvirtError) as exc:
         connection.connection
 
-    assert exc.value is conn.domainEventRegister.side_effect
-    conn.domainEventDeregister.assert_called_once()
+    assert exc.value is conn.domainEventRegisterAny.side_effect
+    # Registration never completed, so there is no id to give back -- only the handle.
+    conn.domainEventDeregisterAny.assert_not_called()
     conn.close.assert_called_once()
     assert connection._connection is None
 
 
 def test_keepalive_failure_discards_handle_and_propagates():
+    """Registration succeeded before keepalive failed, so this handle is pinned by its
+    callback and has to be deregistered as well as closed."""
     manager = Mock()
     conn = _make_conn()
     manager.open.return_value = conn
@@ -174,7 +220,27 @@ def test_keepalive_failure_discards_handle_and_propagates():
         connection.connection
 
     assert exc.value is conn.setKeepAlive.side_effect
-    conn.domainEventDeregister.assert_called_once()
+    conn.domainEventDeregisterAny.assert_called_once_with(0)
+    conn.close.assert_called_once()
+    names = _call_names(conn)
+    assert names.index("domainEventDeregisterAny") < names.index("close")
+    assert connection._connection is None
+
+
+def test_setup_failure_discards_the_handle_whatever_the_error_type():
+    """Registration pins the handle the moment it succeeds, so whether the handle has to
+    be given back depends on setup not having finished -- not on which exception says so."""
+    manager = Mock()
+    conn = _make_conn()
+    manager.open.return_value = conn
+    conn.setKeepAlive.side_effect = RuntimeError("binding changed under us")
+
+    connection = Connection(manager, "uri")
+
+    with pytest.raises(RuntimeError):
+        connection.connection
+
+    conn.domainEventDeregisterAny.assert_called_once_with(0)
     conn.close.assert_called_once()
     assert connection._connection is None
 
@@ -205,6 +271,8 @@ def test_close_of_unopened_connection_does_not_open_one():
 
 
 def test_close_deregisters_and_clears_the_handle():
+    """Explicit teardown has no other user to trip over, so it closes as well as
+    deregisters and the handle is gone by the time it returns."""
     manager = Mock()
     conn = _make_conn()
     manager.open.return_value = conn
@@ -214,9 +282,12 @@ def test_close_deregisters_and_clears_the_handle():
 
     connection._close()
 
-    conn.domainEventDeregister.assert_called_once()
+    conn.domainEventDeregisterAny.assert_called_once_with(0)
     conn.close.assert_called_once()
+    names = _call_names(conn)
+    assert names.index("domainEventDeregisterAny") < names.index("close")
     assert connection._connection is None
+    assert connection._callback_id is None
     manager.open.assert_called_once()  # never reopened just to be closed
 
 
@@ -250,7 +321,7 @@ def test_concurrent_close_closes_once():
     assert connection.connection is conn
 
     n = 8
-    barrier = threading.Barrier(n)
+    barrier = threading.Barrier(n, timeout=30)
 
     def worker() -> None:
         barrier.wait()
@@ -275,7 +346,7 @@ def test_concurrent_access_opens_once():
     connection = Connection(manager, "uri")
 
     n = 8
-    barrier = threading.Barrier(n)
+    barrier = threading.Barrier(n, timeout=30)
     results: list = []
     results_lock = threading.Lock()
 

--- a/tests/libvirtd/test_connection_real_binding.py
+++ b/tests/libvirtd/test_connection_real_binding.py
@@ -1,0 +1,174 @@
+"""Tests for Connection against a real libvirt handle rather than a mock.
+
+The mocked tests can only pin that we call the binding a particular way; they cannot
+see whether the call actually gives the handle back. libvirt's built-in `test` driver
+needs no daemon and delivers real lifecycle events, so it can answer both questions:
+`close()` returns 0 only once the connection is really disposed, which is exactly the
+signal that the event registration has been released.
+
+Each `test:///default` connection is its own private instance, so a handle only ever
+sees events for domains defined through it.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import libvirt
+import pytest
+
+from truenas_pylibvirt.libvirtd.connection import Connection
+
+URI = "test:///default"
+
+DOMAIN_XML = """
+<domain type='test'>
+  <name>{name}</name>
+  <memory unit='KiB'>8192</memory>
+  <os><type arch='i686'>hvm</type></os>
+</domain>
+"""
+
+
+class _Handle:
+    """A real libvirt handle that also answers `setKeepAlive`, can be told to report
+    itself dead, and remembers what `close()` returned.
+
+    The test driver does not implement keepalive, so a bare handle would always send
+    `Connection` down its setup-failure path. `close()`'s return value is the useful
+    part: 0 means libvirt disposed the connection, 1 means something still holds a
+    reference to it -- an event callback that was never given back, for instance.
+    """
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+        self.close_rc: int | None = None
+        self.report_dead = False
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._connection, name)
+
+    def isAlive(self) -> bool:
+        if self.report_dead:
+            return False
+
+        return bool(self._connection.isAlive())
+
+    def setKeepAlive(self, interval: int, count: int) -> int:
+        return 0
+
+    def close(self) -> int:
+        self.close_rc = self._connection.close()
+        return self.close_rc
+
+
+class _Manager:
+    def open(self, uri: str) -> _Handle:
+        return _Handle(libvirt.open(uri))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def libvirt_event_loop():
+    """Registering an event callback needs an event implementation, and something has
+    to run it for callbacks to ever be dispatched."""
+    libvirt.virEventRegisterDefaultImpl()
+
+    stop = threading.Event()
+
+    def run() -> None:
+        while not stop.is_set():
+            libvirt.virEventRunDefaultImpl()
+
+    thread = threading.Thread(target=run, name="test_libvirt_event_loop", daemon=True)
+    thread.start()
+    yield
+    stop.set()
+
+
+def _wait_for(events: list, count: int, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if len(events) >= count:
+            return
+
+        time.sleep(0.01)
+
+    raise AssertionError(f"expected {count} domain events, got {len(events)}: {events}")
+
+
+def test_closing_a_deregistered_handle_disposes_it():
+    """The mutation this exists to catch -- deregistering with the wrong id, or a
+    callback we never registered -- leaves the handle pinned, and `close()` says so."""
+    connection = Connection(_Manager(), URI)
+    handle = connection.connection
+
+    connection._close()
+
+    assert handle.close_rc == 0
+
+
+def test_lifecycle_events_reach_registered_callbacks():
+    connection = Connection(_Manager(), URI)
+    events: list = []
+    connection.register_domain_event_callback(events.append)
+
+    try:
+        handle = connection.connection
+        domain = handle.defineXML(DOMAIN_XML.format(name="pylibvirt-events"))
+        _wait_for(events, 1)
+        # Both events have to arrive before the close: closing gives the registration
+        # back, and nothing delivers events to a handle that no longer holds one.
+        domain.undefine()
+        _wait_for(events, 2)
+    finally:
+        connection._close()
+
+    assert [e.event.value for e in events[:2]] == ["DEFINED", "UNDEFINED"]
+    assert {e.uuid for e in events[:2]} == {"pylibvirt-events"}
+
+
+def test_reconnecting_from_inside_event_dispatch_is_clean(capfd):
+    """The callback runs on the event loop while libvirt is walking its callbacks, so a
+    reconnect from there gives the registration back mid-dispatch. Anything raised there
+    escapes into libvirt's C trampoline, which prints it straight to fd 2 -- past
+    logging, and past anything a debug bundle collects.
+
+    The reconnect has to go through the liveness probe rather than clearing
+    `_connection` directly, or `_open` has nothing to discard and the reentrancy this
+    is about never happens.
+    """
+    connection = Connection(_Manager(), URI)
+    events: list = []
+    triggered = threading.Event()
+    reconnected = threading.Event()
+
+    handle = connection.connection
+
+    def callback(event) -> None:
+        events.append(event)
+        if not triggered.is_set():
+            triggered.set()
+            handle.report_dead = True
+            try:
+                connection.connection
+            finally:
+                reconnected.set()
+
+    connection.register_domain_event_callback(callback)
+
+    try:
+        handle.defineXML(DOMAIN_XML.format(name="pylibvirt-reentrant"))
+        _wait_for(events, 1)
+        assert reconnected.wait(10), "the reconnect never ran inside the dispatch callback"
+
+        # The handle really was replaced, and the replacement really is registered:
+        # driving an event through it proves dispatch survived the deregistration.
+        new_handle = connection.connection
+        assert new_handle is not handle
+        new_handle.defineXML(DOMAIN_XML.format(name="pylibvirt-reentrant-2"))
+        _wait_for(events, 2)
+    finally:
+        connection._close()
+
+    assert "RuntimeError" not in capfd.readouterr().err

--- a/truenas_pylibvirt/libvirtd/connection.py
+++ b/truenas_pylibvirt/libvirtd/connection.py
@@ -149,28 +149,56 @@ class Connection:
         }.get(event, VirDomainEvent.UNKNOWN)
 
     def _open(self) -> None:
-        # Close the connection being replaced so it isn't leaked.
+        # Tear down the connection being replaced so it isn't leaked.
         if self._connection is not None:
             old, self._connection = self._connection, None
             try:
-                old.close()
+                self._discard(old)
             except libvirt.libvirtError:
                 logger.debug("Discarding unusable libvirt connection for %s", self.uri, exc_info=True)
 
         connection = self.manager.open(self.uri)
 
-        connection.domainEventRegister(self._libvirt_event_callback, None)
-        connection.setKeepAlive(5, 3)
+        try:
+            connection.domainEventRegister(self._libvirt_event_callback, None)
+            connection.setKeepAlive(5, 3)
+        except libvirt.libvirtError:
+            # Nothing records this handle yet, so no later code path would tear it down.
+            try:
+                self._discard(connection)
+            except libvirt.libvirtError:
+                logger.debug("Failed to discard libvirt connection for %s after setup error", self.uri, exc_info=True)
+            raise
 
         self._connection = connection
 
     def _close(self) -> None:
+        # Deliberately not `self.connection`: the property would open a handle -- starting
+        # libvirtd along the way -- purely so that it could be closed again.
+        with self._connection_lock:
+            if self._connection is None:
+                return
+
+            old, self._connection = self._connection, None
+
         try:
-            self.connection.close()
+            self._discard(old)
         except libvirt.libvirtError as e:
             raise Error(f"Failed to close libvirt connection: {e}")
 
-        self._connection = None
+    def _discard(self, connection: Any) -> None:
+        # `domainEventRegister` makes libvirt hold a reference on the handle that only
+        # `domainEventDeregister` releases. Closing without deregistering first therefore leaves
+        # the connection open and its object alive for the life of the process, and the abandoned
+        # handle keeps dispatching domain events.
+        # Broad: a handle that cannot be deregistered still has to be closed, and libvirt
+        # raises `KeyError` rather than `libvirtError` for a callback it no longer knows about.
+        try:
+            connection.domainEventDeregister(self._libvirt_event_callback)
+        except Exception:
+            logger.debug("Failed to deregister libvirt domain events for %s", self.uri, exc_info=True)
+
+        connection.close()
 
     def _libvirt_event_callback(self, conn: Any, dom: Any, event: int, detail: int, opaque: Any) -> None:
         domain_event = DomainEvent(uuid=dom.name(), event=self.domain_event(event))

--- a/truenas_pylibvirt/libvirtd/connection.py
+++ b/truenas_pylibvirt/libvirtd/connection.py
@@ -68,7 +68,8 @@ class Connection:
     def __init__(self, manager: ConnectionManager, uri: str):
         self.manager = manager
         self.uri = uri
-        self._connection = None
+        self._connection: Any = None
+        self._callback_id: int | None = None
         self._connection_lock = threading.Lock()
         self._domain_event_callbacks: list[DomainEventCallback] = []
 
@@ -149,28 +150,41 @@ class Connection:
         }.get(event, VirDomainEvent.UNKNOWN)
 
     def _open(self) -> None:
-        # Tear down the connection being replaced so it isn't leaked.
+        # Release the connection being replaced so it isn't leaked, but do not close it:
+        # `connection` hands out the raw handle and drops the lock before its caller makes
+        # an RPC, so another thread can still be inside a call on this one. Closing frees
+        # the connection regardless of who is mid-call, taking it out from under that
+        # thread. Deregistering releases the reference that would otherwise outlive us, so
+        # the handle is disposed once its last user lets go of it.
         if self._connection is not None:
-            old, self._connection = self._connection, None
-            try:
-                self._discard(old)
-            except libvirt.libvirtError:
-                logger.debug("Discarding unusable libvirt connection for %s", self.uri, exc_info=True)
+            old, old_callback_id = self._connection, self._callback_id
+            self._connection, self._callback_id = None, None
+            self._discard(old, old_callback_id, close=False)
 
+        # A libvirtd that accepts the connection but never completes the handshake blocks
+        # here for as long as it stays wedged, with `_connection_lock` held.
         connection = self.manager.open(self.uri)
 
+        callback_id: int | None = None
         try:
-            connection.domainEventRegister(self._libvirt_event_callback, None)
+            callback_id = connection.domainEventRegisterAny(
+                None, libvirt.VIR_DOMAIN_EVENT_ID_LIFECYCLE, self._libvirt_event_callback, None
+            )
             connection.setKeepAlive(5, 3)
-        except libvirt.libvirtError:
-            # Nothing records this handle yet, so no later code path would tear it down.
+        except Exception:
+            # Nothing records this handle yet, so no later code path would tear it down, and
+            # no other thread can be using it either -- so unlike the reconnect path above it
+            # is safe (and necessary) to close it here. Broad, because what this has to catch
+            # is "setup did not finish", not one library's idea of how it failed: registration
+            # can already have pinned the handle by the time the failure happens.
             try:
-                self._discard(connection)
+                self._discard(connection, callback_id)
             except libvirt.libvirtError:
                 logger.debug("Failed to discard libvirt connection for %s after setup error", self.uri, exc_info=True)
             raise
 
         self._connection = connection
+        self._callback_id = callback_id
 
     def _close(self) -> None:
         # Deliberately not `self.connection`: the property would open a handle -- starting
@@ -179,26 +193,32 @@ class Connection:
             if self._connection is None:
                 return
 
-            old, self._connection = self._connection, None
+            old, callback_id = self._connection, self._callback_id
+            self._connection, self._callback_id = None, None
 
         try:
-            self._discard(old)
+            self._discard(old, callback_id)
         except libvirt.libvirtError as e:
             raise Error(f"Failed to close libvirt connection: {e}")
 
-    def _discard(self, connection: Any) -> None:
-        # `domainEventRegister` makes libvirt hold a reference on the handle that only
-        # `domainEventDeregister` releases. Closing without deregistering first therefore leaves
-        # the connection open and its object alive for the life of the process, and the abandoned
-        # handle keeps dispatching domain events.
-        # Broad: a handle that cannot be deregistered still has to be closed, and libvirt
-        # raises `KeyError` rather than `libvirtError` for a callback it no longer knows about.
-        try:
-            connection.domainEventDeregister(self._libvirt_event_callback)
-        except Exception:
-            logger.debug("Failed to deregister libvirt domain events for %s", self.uri, exc_info=True)
+    def _discard(self, connection: Any, callback_id: int | None, close: bool = True) -> None:
+        # Registering an event callback makes libvirt hold a reference on the handle that only
+        # deregistering releases, so a handle that is closed but not deregistered stays open --
+        # and keeps dispatching domain events -- for the life of the process. Deregistering is
+        # what actually lets the handle go, which is why the reconnect path can rely on it alone.
+        #
+        # It is best-effort: the RPC fails once the socket is gone, but libvirt releases the
+        # callback locally before sending it, so the reference is dropped either way. Broad,
+        # because nothing raised while giving the callback back may stop the handle being
+        # released -- which on the reconnect path is all that happens here.
+        if callback_id is not None:
+            try:
+                connection.domainEventDeregisterAny(callback_id)
+            except Exception:
+                logger.debug("Failed to deregister libvirt domain events for %s", self.uri)
 
-        connection.close()
+        if close:
+            connection.close()
 
     def _libvirt_event_callback(self, conn: Any, dom: Any, event: int, detail: int, opaque: Any) -> None:
         domain_event = DomainEvent(uuid=dom.name(), event=self.domain_event(event))


### PR DESCRIPTION
## Problem
libvirt keeps a reference on a connection for as long as a domain event callback is registered against it, so `close()` on its own does not release it: the connection stays open server-side, its Python object is never freed, and the abandoned handle carries on dispatching domain events. That applies to every connection we drop on the reconnect path, i.e. once per libvirtd restart for each of the two connections. Separately, if the event registration or `setKeepAlive` failed we dropped the just-opened handle on the floor with nothing left tearing it down — in the keepalive case the registration had already pinned it, so it leaked for the life of the process.

Fixing the leak by closing the handle turned out to expose two further problems, both measured against a live libvirtd.

Closing the handle being replaced frees it under any thread still inside an RPC on it: `connection` hands out the raw handle and drops `_connection_lock` before its caller makes the call, so a reconnect on one thread can dispose a handle another thread is mid-call on. Under reconnect churn that segfaults in `virGetDomain`. Even without a crash, a `close()` that races an in-flight RPC leaks: libvirt skips the client teardown while the call is outstanding and the completing call never re-checks, so the socket and eventfd are never reclaimed although the Python object is — a handle that every Python-level measurement reports as released while the process keeps its fds.

And the legacy `domainEventRegister` API dispatches by walking a dict of callbacks, so deregistering during dispatch mutates the dict being iterated. A reconnect triggered from inside a domain event callback does exactly that — the stop-event handler re-reads the domain's live state, which goes back through the connection property — and the resulting `RuntimeError` escapes into libvirt's C trampoline, which prints it straight to fd 2. That bypasses logging, so it lands in the journal rather than in a debug bundle.

## Solution
Added a `_discard()` helper that gives the event registration back before disposing of a handle, and routed all three disposal paths through it — the connection being replaced in `_open()`, the half-configured handle when post-open setup fails, and `_close()`.

The handle being replaced is deregistered but **not** closed. Deregistering releases the reference libvirt holds for the event callback, which is the reference that outlives us, so the handle is disposed by refcount as soon as its last user lets go of it — measured at about 1 ms after the discard on a real reconnect, with no cycle to collect. `_close()` and the setup-failure path still close, since neither can have another thread using the handle.

Registration moved to `domainEventRegisterAny` with an explicit `VIR_DOMAIN_EVENT_ID_LIFECYCLE`, whose dispatch reads a per-callback dict and iterates nothing shared. The id is stored alongside the handle, swapped with it under the lock, and passed into `_discard` as a parameter, so a handle is always given back with the id it was registered with. It is checked with `is not None`: the first id on a fresh handle is `0`, and treating that as falsy silently skips the deregister. The two APIs are equivalent on the wire — a legacy register *is* an Any-LIFECYCLE register, and dispatch never distinguishes them — and event sequences are identical on both drivers.

The setup-failure cleanup now triggers on any exception rather than only `libvirtError`: registration pins the handle the moment it succeeds, so whether it has to be given back depends on setup not having finished, not on which exception type reports it. The original error still propagates untouched.

`_close()` also takes `_connection_lock` around the swap now, and uses the raw handle rather than the `connection` property, which would otherwise open a connection (starting libvirtd along the way) purely so that it could be closed again.
