### PR TITLE
NAS-142150 / 27.0.0-BETA.1 / Identify USB passthrough devices by port and fail the start when one is missing (by Qubad786)

### DIFF
--- a/tests/device/test_usb.py
+++ b/tests/device/test_usb.py
@@ -4,7 +4,36 @@ from __future__ import annotations
 from unittest.mock import Mock, patch
 from xml.etree import ElementTree as ET
 
+import pytest
+
+from truenas_pylibvirt import DeviceNotFoundError
 from truenas_pylibvirt.device import USBDevice
+from truenas_pylibvirt.utils.usb import get_usb_device_default_data
+
+
+def _capability(vendor_id, product_id, bus='1', device='2'):
+    """What `find_usb_device_by_libvirt_name` returns for a device that is present.
+
+    Bus and device numbers are unpadded because that is what the lookup produces; a padded
+    fixture would assert against a shape production cannot emit.
+    """
+    details = get_usb_device_default_data()
+    details['capability'].update({
+        'vendor': 'Test vendor',
+        'vendor_id': vendor_id,
+        'product': 'Test product',
+        'product_id': product_id,
+        'bus': bus,
+        'device': device,
+    })
+    details['available'] = True
+    details['description'] = 'Test product by Test vendor'
+    return details
+
+
+def _not_found(device_name):
+    """What it returns for a name whose port holds nothing. Notably, never `None`."""
+    return {**get_usb_device_default_data(), 'error': f'USB device {device_name} not found'}
 
 
 def test_usb_device_exclusive():
@@ -15,16 +44,7 @@ def test_usb_device_exclusive():
 @patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
 def test_usb_device_xml_generation_by_name(mock_find_usb, device_context, mock_device_delegate):
     """Test USB device XML generation using device name."""
-    # Mock USB device details
-    mock_find_usb.return_value = {
-        'capability': {
-            'vendor_id': '0x1234',
-            'product_id': '0x5678',
-            'bus': '001',
-            'device': '002',
-        },
-        'available': True,
-    }
+    mock_find_usb.return_value = _capability('0x1234', '0x5678')
 
     device = USBDevice(
         vendor_id=None,
@@ -48,17 +68,8 @@ def test_usb_device_xml_generation_by_name(mock_find_usb, device_context, mock_d
 @patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
 def test_usb_device_xml_generation_by_ids(mock_find_by_name, mock_find_by_ids, device_context, mock_device_delegate):
     """Test USB device XML generation using vendor/product IDs."""
-    # Mock USB device discovery
     mock_find_by_ids.return_value = "usb_1_1"
-    mock_find_by_name.return_value = {
-        'capability': {
-            'vendor_id': '0x1234',
-            'product_id': '0x5678',
-            'bus': '001',
-            'device': '002',
-        },
-        'available': True,
-    }
+    mock_find_by_name.return_value = _capability('0x1234', '0x5678')
 
     device = USBDevice(
         vendor_id="0x1234",
@@ -107,15 +118,7 @@ def test_usb_identity_with_ids(mock_device_delegate):
 def test_usb_validation_device_and_ids_mutually_exclusive(mock_find_usb, mock_device_delegate):
     """Test that device and IDs cannot both be specified."""
     # Mock USB device discovery to avoid udev dependency
-    mock_find_usb.return_value = {
-        'capability': {
-            'vendor_id': '0x1234',
-            'product_id': '0x5678',
-            'bus': '001',
-            'device': '002',
-        },
-        'available': True,
-    }
+    mock_find_usb.return_value = _capability('0x1234', '0x5678')
 
     device = USBDevice(
         vendor_id="0x1234",
@@ -145,18 +148,6 @@ def test_usb_validation_missing_device_and_ids(mock_device_delegate):
     assert any("must be specified" in error[1] for error in errors)
 
 
-def _capability(vendor_id, product_id, bus='001', device='002'):
-    return {
-        'capability': {
-            'vendor_id': vendor_id,
-            'product_id': product_id,
-            'bus': bus,
-            'device': device,
-        },
-        'available': True,
-    }
-
-
 def _hostdev_bus(hostdev):
     address = hostdev.find("address[@type='usb']")
     return address.get('bus') if address is not None else None
@@ -175,7 +166,7 @@ def test_usb_two_devices_same_type_single_controller(
     mock_find_by_name.side_effect = lambda n: {
         'usb_1_2': _capability('0x80ee', '0x0021'),
         'usb_3_4': _capability('0x0718', '0x7722'),
-    }.get(n)
+    }.get(n) or _not_found(n)
 
     first = USBDevice(
         vendor_id='0x80ee', product_id='0x0021', device=None,
@@ -213,7 +204,7 @@ def test_usb_two_devices_different_types_two_controllers(
     mock_find_by_name.side_effect = lambda n: {
         'usb_1_2': _capability('0x80ee', '0x0021'),
         'usb_3_4': _capability('0x0718', '0x7722'),
-    }.get(n)
+    }.get(n) or _not_found(n)
 
     first = USBDevice(
         vendor_id='0x80ee', product_id='0x0021', device=None,
@@ -245,7 +236,7 @@ def test_usb_nec_xhci_no_controller_bus_zero(mock_find_usb, device_context, mock
     mock_find_usb.side_effect = lambda n: {
         'usb_1_2': _capability('0x80ee', '0x0021'),
         'usb_3_4': _capability('0x0718', '0x7722'),
-    }.get(n)
+    }.get(n) or _not_found(n)
 
     first = USBDevice(
         vendor_id=None, product_id=None, device='usb_1_2',
@@ -287,7 +278,7 @@ def test_usb_mixed_nec_and_qemu_xhci_indices(mock_find_usb, device_context, mock
     mock_find_usb.side_effect = lambda n: {
         'usb_1_2': _capability('0x80ee', '0x0021'),
         'usb_3_4': _capability('0x0718', '0x7722'),
-    }.get(n)
+    }.get(n) or _not_found(n)
 
     nec = USBDevice(
         vendor_id=None, product_id=None, device='usb_1_2',
@@ -329,14 +320,15 @@ def test_usb_port_attribute_omitted(mock_find_usb, device_context, mock_device_d
 
 
 @patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
-def test_usb_unavailable_device_does_not_consume_controller_index(
+def test_usb_missing_device_raises_and_does_not_consume_controller_index(
     mock_find_usb, device_context, mock_device_delegate
 ):
-    """A device whose lookup fails returns nothing before touching the counters, so a later
-    device of the same type still gets the first controller index."""
+    """An empty port aborts the start rather than silently dropping the device, and it does so
+    before touching the counters, so a later device of the same type still gets the first
+    controller index."""
     mock_find_usb.side_effect = lambda n: {
         'usb_3_4': _capability('0x0718', '0x7722'),
-    }.get(n)
+    }.get(n) or _not_found(n)
 
     phantom = USBDevice(
         vendor_id=None, product_id=None, device='usb_missing',
@@ -347,7 +339,8 @@ def test_usb_unavailable_device_does_not_consume_controller_index(
         controller_type='qemu-xhci', device_delegate=mock_device_delegate,
     )
 
-    assert phantom.xml(device_context) == []
+    with pytest.raises(DeviceNotFoundError, match='usb_missing'):
+        phantom.xml(device_context)
 
     real_elements = real.xml(device_context)
     controllers = [e for e in real_elements if e.tag == 'controller']
@@ -366,7 +359,7 @@ def test_usb_interleaved_types_reuse_existing_controller(
         'usb_1_2': _capability('0x80ee', '0x0021'),
         'usb_3_4': _capability('0x0718', '0x7722'),
         'usb_5_6': _capability('0x1d6b', '0x0003'),
-    }.get(n)
+    }.get(n) or _not_found(n)
 
     first_ehci = USBDevice(
         vendor_id=None, product_id=None, device='usb_1_2',
@@ -393,6 +386,46 @@ def test_usb_interleaved_types_reuse_existing_controller(
     assert [e for e in second_elements if e.tag == 'controller'] == []
     second_hostdev = next(e for e in second_elements if e.tag == 'hostdev')
     assert _hostdev_bus(second_hostdev) == first_controller.get('index')
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_ids')
+def test_usb_missing_ids_raise(mock_find_by_ids, device_context, mock_device_delegate):
+    """A device identified by ids that are not connected fails the start instead of being dropped.
+
+    Dropping it silently produced a VM that booted without hardware it was configured with, which
+    nothing we expose records: the row is still listed, and the domain XML never mentions it.
+    """
+    mock_find_by_ids.return_value = None
+
+    device = USBDevice(
+        vendor_id='0x0718', product_id='0x7722', device=None,
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+
+    with pytest.raises(DeviceNotFoundError, match='0x7722'):
+        device.xml(device_context)
+
+
+@patch('truenas_pylibvirt.device.usb.find_usb_device_by_libvirt_name')
+def test_usb_xml_serialises(mock_find_usb, device_context, mock_device_delegate):
+    """The generated elements survive serialisation.
+
+    A lookup that failed used to yield a capability full of `None`s, which builds an element tree
+    happily and only blows up here, far from anything naming USB.
+    """
+    mock_find_usb.return_value = _capability('0x80ee', '0x0021')
+
+    device = USBDevice(
+        vendor_id=None, product_id=None, device='usb_1_2',
+        controller_type='qemu-xhci', device_delegate=mock_device_delegate,
+    )
+
+    hostdev = next(e for e in device.xml(device_context) if e.tag == 'hostdev')
+    serialised = ET.tostring(hostdev, encoding='unicode')
+
+    assert 'id="0x80ee"' in serialised
+    assert 'id="0x0021"' in serialised
+    assert 'bus="1" device="2"' in serialised
 
 
 def test_usb_conflict_detection(mock_device_delegate):

--- a/tests/utils/test_usb.py
+++ b/tests/utils/test_usb.py
@@ -1,0 +1,105 @@
+"""Tests for building USB device names from the port a device is plugged into."""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from truenas_pylibvirt.utils.usb import (
+    find_usb_device_by_ids,
+    find_usb_device_by_libvirt_name,
+    get_all_usb_devices,
+    libvirt_device_name,
+)
+
+
+def _udev_device(sys_name, busnum, devnum, vendor_id='0627', product_id='0001', device_class='00'):
+    device = Mock()
+    device.sys_name = sys_name
+    device.properties = {
+        'BUSNUM': busnum,
+        'DEVNUM': devnum,
+        'ID_VENDOR_ID': vendor_id,
+        'ID_MODEL_ID': product_id,
+        'ID_VENDOR_FROM_DATABASE': 'Adomax Technology Co., Ltd',
+        'ID_MODEL_FROM_DATABASE': 'QEMU Tablet',
+    }
+    device.attributes.get.return_value = device_class.encode()
+    return device
+
+
+@pytest.fixture
+def udev_devices():
+    """A device on a port whose number differs from its device number, plus one behind a hub."""
+    devices = [
+        _udev_device('usb1', '001', '001', vendor_id='1d6b', product_id='0002', device_class='09'),  # root hub
+        _udev_device('1-1', '001', '002'),
+        _udev_device('1-4.2', '001', '003', vendor_id='46f4', product_id='0002'),
+    ]
+    with patch('truenas_pylibvirt.utils.usb.Context') as context:
+        context.return_value.list_devices.return_value = devices
+        yield devices
+
+
+@pytest.mark.parametrize('sys_name,expected', [
+    ('1-1', 'usb_1_1'),
+    ('1-4.2', 'usb_1_4_2'),
+    ('2-10.3.1', 'usb_2_10_3_1'),
+])
+def test_libvirt_device_name_from_port(sys_name, expected):
+    """A device name is the port path with its separators turned into underscores."""
+    assert libvirt_device_name(sys_name) == expected
+
+
+def test_get_all_usb_devices_keyed_by_port(udev_devices):
+    """Devices are keyed by their port, not by the device number the kernel handed them."""
+    devices = get_all_usb_devices()
+
+    assert sorted(devices) == ['usb_1_1', 'usb_1_4_2']
+    # Root hubs are not passthrough candidates
+    assert 'usb_usb1' not in devices
+
+
+def test_find_usb_device_by_libvirt_name_resolves_port(udev_devices):
+    """The name names a port, so it resolves to whatever is plugged in there."""
+    details = find_usb_device_by_libvirt_name('usb_1_1')
+
+    assert details['error'] is None
+    assert details['available'] is True
+    # The device number is resolved fresh rather than read out of the name
+    assert details['capability']['bus'] == '1'
+    assert details['capability']['device'] == '2'
+
+
+def test_find_usb_device_by_libvirt_name_behind_hub(udev_devices):
+    """A device behind a hub carries the whole port path in its name."""
+    details = find_usb_device_by_libvirt_name('usb_1_4_2')
+
+    assert details['error'] is None
+    assert details['capability']['product_id'] == '0x0002'
+
+
+def test_find_usb_device_by_libvirt_name_not_found(udev_devices):
+    """A name whose port holds nothing reports that rather than resolving to another device."""
+    details = find_usb_device_by_libvirt_name('usb_1_2')
+
+    assert details['error'] == 'USB device usb_1_2 not found'
+    assert details['available'] is False
+
+
+def test_find_usb_device_by_ids_returns_port_name(udev_devices):
+    """Looking a device up by its ids yields the name of the port it occupies."""
+    assert find_usb_device_by_ids('0x46f4', '0x0002') == 'usb_1_4_2'
+
+
+def test_find_usb_device_by_libvirt_name_never_returns_a_hub(udev_devices):
+    """A stored name that reaches a hub resolves to nothing rather than to the whole bus."""
+    details = find_usb_device_by_libvirt_name('usb_usb1')
+
+    assert details['error'] == 'USB device usb_usb1 not found'
+    assert details['available'] is False
+
+
+def test_find_usb_device_by_ids_never_returns_a_hub(udev_devices):
+    """The ids of a hub name no passthrough candidate either."""
+    assert find_usb_device_by_ids('0x1d6b', '0x0002') is None

--- a/truenas_pylibvirt/__init__.py
+++ b/truenas_pylibvirt/__init__.py
@@ -12,7 +12,7 @@ from .domain.vm.configuration import (  # noqa
     VmBootloader, VmCpuMode, VmDomainConfiguration,
 )
 from .domain.vm.domain import VmDomain  # noqa
-from .error import Error, DomainDoesNotExistError, GuestAgentError, is_no_domain_error  # noqa
+from .error import DeviceNotFoundError, Error, DomainDoesNotExistError, GuestAgentError, is_no_domain_error  # noqa
 from .libvirtd.connection import Connection  # noqa
 from .libvirtd.connection_manager import ConnectionManager  # noqa
 from .libvirtd.service_delegate import ServiceDelegate  # noqa
@@ -28,6 +28,7 @@ __all__ = [
     'BaseDomain',
     'DEFAULT_CONTAINERS_URI',
     'DEFAULT_VMS_URI',
+    'DeviceNotFoundError',
     'DiskStorageDevice',
     'DomainDoesNotExistError',
     'DomainManagers',

--- a/truenas_pylibvirt/device/usb.py
+++ b/truenas_pylibvirt/device/usb.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 from xml.etree import ElementTree
 
+from ..error import DeviceNotFoundError
 from ..xml import xml_element
 from .base import Device, DeviceXmlContext
 from ..utils.usb import find_usb_device_by_libvirt_name, find_usb_device_by_ids
@@ -20,11 +21,7 @@ class USBDevice(Device):
     controller_type: str | None
 
     def xml(self, context: DeviceXmlContext) -> list[ElementTree.Element]:
-        usb_details = self.get_usb_details()
-        if usb_details is None:
-            return []
-
-        capability = usb_details['capability']
+        capability = self.resolve()['capability']
         children = [
             xml_element(
                 "source",
@@ -90,6 +87,34 @@ class USBDevice(Device):
     def identity_impl(self) -> str:
         return self.device or f"{self.product_id}--{self.vendor_id}"
 
+    def resolve(self) -> dict[str, Any]:
+        """
+        Live details of the configured USB device.
+
+        The bus and device numbers written into the domain XML are whatever the kernel has
+        assigned right now, so they are read here rather than taken from configuration. A device
+        that cannot be resolved raises: a domain that quietly starts without a passthrough device
+        it was configured with is indistinguishable, from every surface we expose, from one that
+        got it.
+        """
+        details = self.get_usb_details()
+        if details is None or details.get('error'):
+            raise DeviceNotFoundError(self.not_found_message())
+
+        return details
+
+    def not_found_message(self) -> str:
+        if self.device:
+            return (
+                f'No USB device is connected at {self.device}. Plug the device back into the same '
+                'port, or reconfigure this VM to use the port it is now plugged into.'
+            )
+
+        return (
+            f'No USB device with vendor ID {self.vendor_id} and product ID {self.product_id} is '
+            'connected to this system.'
+        )
+
     def get_usb_details(self) -> dict[str, Any] | None:
         if self.device:
             return find_usb_device_by_libvirt_name(self.device)
@@ -121,21 +146,10 @@ class USBDevice(Device):
             )
 
         usb_device_details = self.get_usb_details()
-        if self.device:
-            if not usb_device_details:
-                verrors.append(("device", f"No USB device found with name {self.device}"))
-            elif usb_device_details.get("error"):
-                verrors.append(("device", usb_device_details["error"]))
-        else:
-            if not usb_device_details:
-                verrors.append(
-                    (
-                        "usb",
-                        f"No USB device found with Vendor ID {self.vendor_id} and Product ID {self.product_id}"
-                    )
-                )
-            elif usb_device_details.get("error"):
-                verrors.append(("usb", usb_device_details["error"]))
+        if not usb_device_details or usb_device_details.get("error"):
+            # Same wording the start path uses, so what the user is told when configuring the
+            # device and what they are told when it fails to start cannot drift apart.
+            verrors.append(("device" if self.device else "usb", self.not_found_message()))
 
         return verrors
 

--- a/truenas_pylibvirt/error.py
+++ b/truenas_pylibvirt/error.py
@@ -1,10 +1,14 @@
 import libvirt
 
-__all__ = ["Error", "DomainDoesNotExistError", "GuestAgentError", "is_no_domain_error"]
+__all__ = ["Error", "DeviceNotFoundError", "DomainDoesNotExistError", "GuestAgentError", "is_no_domain_error"]
 
 
 class Error(Exception):
     pass
+
+
+class DeviceNotFoundError(Error):
+    """A device a domain is configured to pass through is not present on the host."""
 
 
 class DomainDoesNotExistError(Error):

--- a/truenas_pylibvirt/utils/usb.py
+++ b/truenas_pylibvirt/utils/usb.py
@@ -38,6 +38,37 @@ def parse_libvirt_device_name(device_name: str) -> tuple[str, str] | None:
     return None
 
 
+def is_usb_hub(udev_device: UdevDevice) -> bool:
+    """
+    Whether a udev device is a USB hub, root hubs included.
+
+    A hub is never a passthrough candidate: a root hub is the bus itself, and handing a guest a
+    hub hands it everything plugged into that hub.
+    """
+    try:
+        device_class = udev_device.attributes.get('bDeviceClass')
+    except (AttributeError, UnicodeDecodeError):
+        return False
+
+    return bool(device_class) and device_class.decode('utf-8', errors='ignore') == '09'
+
+
+def libvirt_device_name(sys_name: str) -> str:
+    """
+    Build the libvirt device name of a USB device from its sysfs port path.
+
+    The port path is the physical socket the device is plugged into (e.g. "1-2", or "1-4.2" for a
+    device behind a hub) and stays the same across replugs and reboots, unlike the device number.
+
+    Args:
+        sys_name: Sysfs port path like "1-2" or "1-4.2"
+
+    Returns:
+        Libvirt device name (e.g., "usb_1_2" or "usb_1_4_2")
+    """
+    return f'usb_{sys_name.replace("-", "_").replace(".", "_")}'
+
+
 def get_usb_device_details(udev_device: UdevDevice) -> dict[str, Any]:
     """Extract USB device details from udev device."""
     data = get_usb_device_default_data()
@@ -105,30 +136,10 @@ def find_usb_device_by_libvirt_name(device_name: str) -> dict[str, Any]:
     Returns:
         Device details dict or dict with error
     """
-    # Parse the libvirt name to get bus and device numbers
-    parsed = parse_libvirt_device_name(device_name)
-    if not parsed:
-        return {
-            **get_usb_device_default_data(),
-            'error': f'Invalid device name format: {device_name}'
-        }
-
-    target_bus, target_devnum = parsed
-
-    # Convert to string format with leading zeros if needed
-    target_bus = target_bus.lstrip('0') or '0'
-
     context = Context()
-    # Look for USB devices matching the bus and device number
+    # Look for the USB device currently plugged into the port the name refers to
     for device in context.list_devices(subsystem='usb', DEVTYPE='usb_device'):
-        props = device.properties
-
-        # Get bus and device numbers
-        bus = props.get('BUSNUM', '').lstrip('0') or '0'
-        devnum = props.get('DEVNUM', '').lstrip('0') or '0'
-
-        # Check if this matches our target
-        if bus == target_bus and devnum == target_devnum:
+        if libvirt_device_name(device.sys_name) == device_name and not is_usb_hub(device):
             return get_usb_device_details(device)
 
     return {
@@ -156,6 +167,9 @@ def find_usb_device_by_ids(vendor_id: str, product_id: str) -> str | None:
     product_id = product_id.lower().replace('0x', '')
 
     for device in context.list_devices(subsystem='usb', DEVTYPE='usb_device'):
+        if is_usb_hub(device):
+            continue
+
         props = device.properties
 
         # Get device IDs (they're already without 0x prefix in pyudev)
@@ -163,10 +177,8 @@ def find_usb_device_by_ids(vendor_id: str, product_id: str) -> str | None:
         device_product = props.get('ID_MODEL_ID', '').lower()
 
         if device_vendor == vendor_id and device_product == product_id:
-            # Build libvirt device name from bus and device numbers
-            bus = props.get('BUSNUM', '').lstrip('0') or '0'
-            devnum = props.get('DEVNUM', '').lstrip('0') or '0'
-            return f"usb_{bus}_{devnum}"
+            # Build libvirt device name from the port the device is plugged into
+            return libvirt_device_name(device.sys_name)
 
     return None
 
@@ -182,19 +194,10 @@ def get_all_usb_devices() -> dict[str, dict[str, Any]]:
     context = Context()
 
     for device in context.list_devices(subsystem='usb', DEVTYPE='usb_device'):
-        # Skip root hubs (they have bDeviceClass=09)
-        try:
-            device_class = device.attributes.get('bDeviceClass')
-            if device_class and device_class.decode('utf-8', errors='ignore') == '09':
-                continue
-        except (AttributeError, UnicodeDecodeError):
-            pass
+        if is_usb_hub(device):
+            continue
 
-        props = device.properties
-        bus = props.get('BUSNUM', '').lstrip('0') or '0'
-
-        devnum = props.get('DEVNUM', '').lstrip('0') or '0'
-        device_name = f"usb_{bus}_{devnum}"
+        device_name = libvirt_device_name(device.sys_name)
 
         # Skip if already added (shouldn't happen but just in case)
         if device_name not in result:


### PR DESCRIPTION
## Problem

Two separate defects in USB passthrough, both of which end with a guest getting hardware that isn't the hardware the admin picked.

**The stored name was being read as a device number.** `utils/usb.py` parsed a stored `usb_<a>_<b>` value into a bus and a device number, but every value TrueNAS 25.10 and earlier wrote is a libvirt nodedev name, which libvirt builds from the sysfs port path. A device number is an enumeration counter the kernel reissues on every replug and every reboot, so those stored values silently resolved to whichever device happened to hold that number at the time. Because the kernel hands devnum 1 to each bus's root hub, `usb_<bus>_1` always landed on a root hub and reported itself available with no error — passing a guest the whole bus. Hub-attached names like `usb_1_4_2` did not parse at all, so devices behind a hub were unusable.

**A missing device was not a start failure.** `USBDevice.xml()` guarded on the lookup returning `None`, but the two lookups disagree about how they report a miss. `find_usb_device_by_libvirt_name` always returns a dict, so a name whose port holds nothing never tripped the guard: the hostdev was built with `None` for every id and the domain XML then failed to serialise with `TypeError: cannot serialize None`, a message naming neither USB, nor the device, nor the VM. `find_usb_device_by_ids` does return `None`, so there the guard fired and the hostdev was dropped instead — the VM started without hardware it was configured with, and nothing we expose records that, since the row is still listed and the domain XML never mentions it. Switching to port-based identity makes the first case ordinary rather than rare, because an empty port now legitimately resolves to nothing.

## Solution

**Names are built from and matched against the sysfs port path**, which is what libvirt has always used. A stored value once again names the socket the admin picked, the device number is resolved fresh on every lookup instead of being read out of the name, and devices behind a hub are addressable for the first time.

**Hub filtering moved into a shared `is_usb_hub` helper and applies on every lookup path.** It previously existed only in the choices list, so it governed what you could see rather than what you could get, and anything that didn't come through the picker — stale rows, direct API calls — resolved to a hub anyway. A hub is never a passthrough candidate: a root hub is the bus itself, and handing a guest an external hub hands it everything plugged into that hub.

**Both lookup paths go through one `resolve()` that raises `DeviceNotFoundError`** naming the port or the ids it could not find. Configure-time validation shares that message, so what the user is told when adding a device and what they are told when it fails to start cannot drift apart. Nothing else needed changing: an exception out of XML generation already unwinds the devices staged for the start.

Together these two are what make a hub safe to refuse — the filter makes a hub unresolvable, and `resolve()` turns unresolvable into a loud, named failure instead of a bus quietly disappearing into a guest.



Original PR: https://github.com/truenas/truenas_pylibvirt/pull/81
