### PR TITLE
NAS-142266 / 27.0.0-BETA.1 / Present libvirt failures as this package's own error type (by Qubad786)

### DIFF
--- a/tests/test_libvirt_errors_as_error.py
+++ b/tests/test_libvirt_errors_as_error.py
@@ -1,0 +1,79 @@
+import libvirt
+import pytest
+
+from truenas_pylibvirt import DomainDoesNotExistError, Error
+from truenas_pylibvirt.error import libvirt_errors_as_error
+
+
+def _libvirt_error(code, message="error"):
+    e = libvirt.libvirtError(message)
+    e.err = (code, None, message, None, None, None, None, -1, -1)
+    return e
+
+
+def test_a_libvirt_error_comes_out_as_ours():
+    @libvirt_errors_as_error
+    def entry_point():
+        raise libvirt.libvirtError("XML error: unsupported configuration")
+
+    with pytest.raises(Error) as exc_info:
+        entry_point()
+
+    assert not isinstance(exc_info.value, libvirt.libvirtError)
+    assert "XML error: unsupported configuration" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, libvirt.libvirtError)
+
+
+def test_a_domain_that_is_already_gone_keeps_its_own_type():
+    """A call racing an undefine reports VIR_ERR_NO_DOMAIN, which callers treat as nothing to do."""
+    @libvirt_errors_as_error
+    def entry_point():
+        raise _libvirt_error(libvirt.VIR_ERR_NO_DOMAIN, "Domain not found")
+
+    with pytest.raises(DomainDoesNotExistError) as exc_info:
+        entry_point()
+
+    assert "Domain not found" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, libvirt.libvirtError)
+
+
+def test_any_other_libvirt_code_is_not_a_missing_domain():
+    @libvirt_errors_as_error
+    def entry_point():
+        raise _libvirt_error(libvirt.VIR_ERR_INTERNAL_ERROR)
+
+    with pytest.raises(Error) as exc_info:
+        entry_point()
+
+    assert not isinstance(exc_info.value, DomainDoesNotExistError)
+
+
+def test_our_own_errors_pass_through_unchanged():
+    """Wrapping a DomainDoesNotExistError in a plain Error would lose what callers switch on."""
+    raised = DomainDoesNotExistError("gone")
+
+    @libvirt_errors_as_error
+    def entry_point():
+        raise raised
+
+    with pytest.raises(DomainDoesNotExistError) as exc_info:
+        entry_point()
+
+    assert exc_info.value is raised
+
+
+def test_everything_else_passes_through_unchanged():
+    @libvirt_errors_as_error
+    def entry_point():
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError):
+        entry_point()
+
+
+def test_the_return_value_and_arguments_survive():
+    @libvirt_errors_as_error
+    def entry_point(a, b, c=3):
+        return a, b, c
+
+    assert entry_point(1, b=2) == (1, 2, 3)

--- a/truenas_pylibvirt/domain/manager.py
+++ b/truenas_pylibvirt/domain/manager.py
@@ -8,7 +8,7 @@ from typing import Any
 from xml.etree import ElementTree
 
 from .. import runtime
-from ..error import Error, DomainDoesNotExistError, is_no_domain_error
+from ..error import Error, DomainDoesNotExistError, is_no_domain_error, libvirt_errors_as_error
 from ..libvirtd.connection import Connection, DomainEvent, DomainState, VirDomainEvent
 from .base.domain import BaseDomain
 from .start_validator import StartValidator, StartValidationContext
@@ -41,6 +41,7 @@ class DomainManager:
 
         self.connection.register_domain_event_callback(self._domain_event_callback)
 
+    @libvirt_errors_as_error
     def start(self, domain: BaseDomain) -> None:
         with self.started_domains_lock:
             if started_domain := self.started_domains.get(domain.configuration.uuid):
@@ -96,6 +97,7 @@ class DomainManager:
                 else:
                     started_domain.cleanup()
 
+    @libvirt_errors_as_error
     def shutdown(self, domain: BaseDomain, shutdown_timeout: int | None = None) -> None:
         libvirt_domain = self._libvirt_domain_for_stop(domain)
 
@@ -112,6 +114,7 @@ class DomainManager:
             shutdown_timeout -= 1
             time.sleep(1)
 
+    @libvirt_errors_as_error
     def destroy(self, domain: BaseDomain) -> None:
         libvirt_domain = self._libvirt_domain_for_stop(domain)
         self._destroy(libvirt_domain)
@@ -128,14 +131,17 @@ class DomainManager:
 
             raise
 
+    @libvirt_errors_as_error
     def reset(self, domain: BaseDomain) -> None:
         libvirt_domain = self._libvirt_domain_for_stop(domain)
         libvirt_domain.reset(0)
 
+    @libvirt_errors_as_error
     def suspend(self, domain: BaseDomain) -> None:
         libvirt_domain = self._libvirt_domain_for_stop(domain)
         libvirt_domain.suspend()
 
+    @libvirt_errors_as_error
     def resume(self, domain: BaseDomain) -> None:
         libvirt_domain = self._libvirt_domain(domain)
 
@@ -144,6 +150,7 @@ class DomainManager:
 
         libvirt_domain.resume()
 
+    @libvirt_errors_as_error
     def delete(self, domain: BaseDomain) -> None:
         libvirt_domain = self._libvirt_domain(domain)
         if self.connection.domain_state(libvirt_domain) in [DomainState.RUNNING, DomainState.PAUSED]:

--- a/truenas_pylibvirt/error.py
+++ b/truenas_pylibvirt/error.py
@@ -1,6 +1,15 @@
+import functools
+from typing import Callable, ParamSpec, TypeVar
+
 import libvirt
 
-__all__ = ["Error", "DeviceNotFoundError", "DomainDoesNotExistError", "GuestAgentError", "is_no_domain_error"]
+__all__ = [
+    "Error", "DeviceNotFoundError", "DomainDoesNotExistError", "GuestAgentError", "is_no_domain_error",
+    "libvirt_errors_as_error",
+]
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class Error(Exception):
@@ -17,6 +26,34 @@ class DomainDoesNotExistError(Error):
 
 class GuestAgentError(Error):
     pass
+
+
+def libvirt_errors_as_error(f: Callable[P, R]) -> Callable[P, R]:
+    """Present a libvirt failure from a public entry point as this package's own error type.
+
+    `libvirt.libvirtError` is libvirt's exception, not ours, and it is what libvirt raises for the
+    ordinary things: refusing a generated domain definition, failing to launch the guest. A caller
+    that wants to report those as anything other than a traceback has to import libvirt itself just
+    to name the type, which defeats the point of this package existing.
+
+    A domain that is already gone keeps its own type. libvirt reports that as an ordinary failure
+    of whatever call raced with the undefine, and a caller treating "already gone" as nothing to do
+    can only recognise it if the distinction survives this conversion.
+
+    Only for the outermost layer. The handling underneath inspects libvirt error codes and has to
+    keep seeing the original exception.
+    """
+    @functools.wraps(f)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return f(*args, **kwargs)
+        except libvirt.libvirtError as e:
+            if is_no_domain_error(e):
+                raise DomainDoesNotExistError(str(e)) from e
+
+            raise Error(str(e)) from e
+
+    return wrapper
 
 
 def is_no_domain_error(exc: BaseException) -> bool:


### PR DESCRIPTION
## Problem
`libvirt.libvirtError` is libvirt's exception, not this package's, and it is what libvirt raises for the ordinary things: refusing a generated domain definition, failing to launch a guest. It escapes every public `DomainManager` method, so a caller that wants to report one of those as anything other than a traceback has to import libvirt itself just to name the type, which defeats the point of this package existing.

## Solution
A decorator converts `libvirt.libvirtError` to `Error`, keeping the original as the cause, and is applied to the six public `DomainManager` methods. It sits at the outermost layer only: the handling underneath inspects libvirt error codes and has to keep seeing the original exception.

Original PR: https://github.com/truenas/truenas_pylibvirt/pull/83
